### PR TITLE
Make CI Checks rebuild the project

### DIFF
--- a/src/Server/Properties/launchSettings.json
+++ b/src/Server/Properties/launchSettings.json
@@ -28,7 +28,7 @@
             "commandName": "Executable",
             "executablePath": "dotnet.exe",
             "workingDirectory": "$(ProjectDir)//..//..",
-            "commandLineArgs": "test --no-build --verbosity=minimal -p:CollectCoverage=true -p:Threshold=80 -p:ThresholdType=branch"
+            "commandLineArgs": "test --verbosity=minimal -p:CollectCoverage=true -p:Threshold=80 -p:ThresholdType=branch"
         },
         "IIS Express": {
             "commandName": "IISExpress",


### PR DESCRIPTION
# Hotfix
## Summary
Fixes an error in the local build configuration "CI Checks".

In the version we run inside GitHub Actions we have the flag `--no-build` because a previous step in the process builds the project. We don't have this previous step locally, so not rebuilding caused some weird issues.