### PR TITLE
Hotfix empty string search

### DIFF
--- a/src/Application/Search/Modules/EmptySearch.cs
+++ b/src/Application/Search/Modules/EmptySearch.cs
@@ -1,0 +1,19 @@
+﻿namespace Application.Search.Modules;
+
+/// <summary>
+/// Matches all contracts against an empty query.
+/// </summary>
+/// <typeparam name="TEntity">The type of the entity to always match empty queries against.</typeparam>
+public class EmptySearch<TEntity> : ISearchModule<TEntity>
+{
+    /// <summary>
+    /// Matches an entity against a query only if it is empty.
+    /// </summary>
+    /// <param name="entity">The entity to match against.</param>
+    /// <param name="query">The text input query.</param>
+    /// <returns>Whether the query is empty or not.</returns>
+    public bool Match(TEntity entity, string query)
+    {
+        return string.IsNullOrEmpty(query);
+    }
+}

--- a/src/Application/Search/Modules/EmptySearch.cs
+++ b/src/Application/Search/Modules/EmptySearch.cs
@@ -9,7 +9,7 @@ public class EmptySearch<TEntity> : ISearchModule<TEntity>
     /// <summary>
     /// Matches an entity against a query only if it is empty.
     /// </summary>
-    /// <param name="entity">The entity to match against.</param>
+    /// <param name="entity">The entity is completely ignored.</param>
     /// <param name="query">The text input query.</param>
     /// <returns>Whether the query is empty or not.</returns>
     public bool Match(TEntity entity, string query)

--- a/src/Application/Search/Modules/SimpleTextSearch.cs
+++ b/src/Application/Search/Modules/SimpleTextSearch.cs
@@ -26,6 +26,9 @@ public class SimpleTextSearch : ISearchModule<Contract>
     /// <returns>Whether the contract matches the name in the query or not.</returns>
     public bool Match(Contract entity, string query)
     {
+        if (string.IsNullOrEmpty(query))
+            return false;
+
         string text = _selector(entity);
         return text.Contains(query, StringComparison.OrdinalIgnoreCase) ||
                query.Contains(text, StringComparison.OrdinalIgnoreCase);

--- a/src/Application/Search/SearchEngine.cs
+++ b/src/Application/Search/SearchEngine.cs
@@ -1,5 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 
+using Application.Search.Modules;
+
 namespace Application.Search;
 
 /// <summary>
@@ -8,7 +10,10 @@ namespace Application.Search;
 /// <typeparam name="TEntity">The type of the entities to perform queries on.</typeparam>
 public class SearchEngine<TEntity>
 {
-    private readonly ICollection<ISearchModule<TEntity>> _modules = new List<ISearchModule<TEntity>>();
+    private readonly ICollection<ISearchModule<TEntity>> _modules = new List<ISearchModule<TEntity>>
+    {
+        new EmptySearch<TEntity>(), // By default the only module is the one that matches on empty queries.
+    };
 
     /// <summary>
     /// Performs a search on the entities, returning the ones that match the query.
@@ -19,9 +24,6 @@ public class SearchEngine<TEntity>
     [SuppressMessage("Style", "IDE0046:Convert to conditional expression", Justification = "Readability.")]
     public IEnumerable<TEntity> Search(string query, IEnumerable<TEntity> entities)
     {
-        if (string.IsNullOrEmpty(query) || !_modules.Any())
-            return entities;
-
         return entities.Where(entity => _modules.Any(module => module.Match(entity, query)))
                        .ToList();
     }

--- a/tests/Application.Tests/Search/Modules/SimpleTextSearchModuleTests.cs
+++ b/tests/Application.Tests/Search/Modules/SimpleTextSearchModuleTests.cs
@@ -29,7 +29,7 @@ public class SimpleTextSearchModuleTests
     }
 
     [Fact]
-    public void Match_ReturnsTrue_WhenQueryIsEmpty()
+    public void Match_ReturnsFalse_WhenQueryIsEmpty()
     {
         // Arrange
         var contract = new Contract { Name = "Contract name", };
@@ -38,7 +38,7 @@ public class SimpleTextSearchModuleTests
         bool matches = _cut.Match(contract, string.Empty);
 
         // Assert
-        matches.Should().BeTrue();
+        matches.Should().BeFalse();
     }
 
     [Fact]

--- a/tests/Application.Tests/Search/SearchEngineTests.cs
+++ b/tests/Application.Tests/Search/SearchEngineTests.cs
@@ -28,19 +28,6 @@ public class SearchEngineTests
     }
 
     [Fact]
-    public void Search_ReturnsAllEntities_WhenThereAreNoModules()
-    {
-        // Arrange
-        int[] entities = { 1, 2, 3, 4, };
-
-        // Act
-        IEnumerable<int> results = _cut.Search("59", entities);
-
-        // Assert
-        results.Should().BeEquivalentTo(entities);
-    }
-
-    [Fact]
     public void SearchWithModule_ReturnsResultsDependingOnTheModule()
     {
         // Arrange


### PR DESCRIPTION
## Summary
Makes all standard modules never match on empty queries. Instead, there is a specific module that only matches on empty queries, and that module is included inside of the search engine by default.
