### PR TITLE
86 differentiate admin from user

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,7 +12,7 @@ on:
 env:
     UNTRUSTED_CONNECTION: true
     prodigo_portal_jwt_secret: "test-json-web-token-secret"
-    prodigo_portal_db_connectionstring: "Server=localhost;Database=master_test_user;User Id=SA; Password=ASDjk_shd$$jkASKJ19821;"
+    prodigo_portal_db_connectionstring: "Server=localhost;Database=master_test;User Id=SA; Password=ASDjk_shd$$jkASKJ19821;"
 
 jobs:
   build-and-test:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -37,11 +37,11 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore
+    - name: Presentation.Tests
+      run: dotnet test --no-build tests/Presentation.Tests -p:CollectCoverage=true   -p:Threshold=80 -p:ThresholdType=branch -p:CoverletOutput=../../CoverageResults/ -p:MergeWith="../../CoverageResults/coverage.json" -p:CoverletOutputFormat="opencover" -p:ExcludeByFile=\"**/Program.cs\" -p:ExcludeByAttribute=\"Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute,ExcludeFromCodeCoverageAttribute\" -p:Include=\"[Client]*,[Server]*\"
+    - name: Infrastructure.Tests
+      run: dotnet test --no-build tests/Infrastructure.Tests -p:CollectCoverage=true -p:Threshold=80 -p:ThresholdType=branch -p:CoverletOutput=../../CoverageResults/ -p:MergeWith="../../CoverageResults/coverage.json"                                     -p:ExcludeByFile=\"**/Program.cs\" -p:ExcludeByAttribute=\"Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute,ExcludeFromCodeCoverageAttribute\" -p:Include=\"[Infrastructure]*\"
     - name: Application.Tests
       run: dotnet test --no-build tests/Application.Tests -p:CollectCoverage=true    -p:Threshold=80 -p:ThresholdType=branch -p:CoverletOutput=../../CoverageResults/                                                                                        -p:ExcludeByFile=\"**/Program.cs\" -p:ExcludeByAttribute=\"Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute,ExcludeFromCodeCoverageAttribute\" -p:Include=\"[Application]*\"
     - name: Domain.Tests
       run: dotnet test --no-build tests/Domain.Tests -p:CollectCoverage=true         -p:Threshold=80 -p:ThresholdType=branch -p:CoverletOutput=../../CoverageResults/ -p:MergeWith="../../CoverageResults/coverage.json"                                     -p:ExcludeByFile=\"**/Program.cs\" -p:ExcludeByAttribute=\"Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute,ExcludeFromCodeCoverageAttribute\" -p:Include=\"[Domain]*\"
-    - name: Infrastructure.Tests
-      run: dotnet test --no-build tests/Infrastructure.Tests -p:CollectCoverage=true -p:Threshold=80 -p:ThresholdType=branch -p:CoverletOutput=../../CoverageResults/ -p:MergeWith="../../CoverageResults/coverage.json"                                     -p:ExcludeByFile=\"**/Program.cs\" -p:ExcludeByAttribute=\"Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute,ExcludeFromCodeCoverageAttribute\" -p:Include=\"[Infrastructure]*\"
-    - name: Presentation.Tests
-      run: dotnet test --no-build tests/Presentation.Tests -p:CollectCoverage=true   -p:Threshold=80 -p:ThresholdType=branch -p:CoverletOutput=../../CoverageResults/ -p:MergeWith="../../CoverageResults/coverage.json" -p:CoverletOutputFormat="opencover" -p:ExcludeByFile=\"**/Program.cs\" -p:ExcludeByAttribute=\"Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute,ExcludeFromCodeCoverageAttribute\" -p:Include=\"[Client]*,[Server]*\"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,6 +12,7 @@ on:
 env:
     UNTRUSTED_CONNECTION: true
     prodigo_portal_jwt_secret: "test-json-web-token-secret"
+    prodigo_portal_db_connectionstring: "Server=localhost;Database=master_test_user;User Id=SA; Password=ASDjk_shd$$jkASKJ19821;"
 
 jobs:
   build-and-test:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,6 +11,7 @@ on:
 
 env:
     UNTRUSTED_CONNECTION: true
+    prodigo_portal_jwt_secret: "test-json-web-token-secret"
 
 jobs:
   build-and-test:

--- a/src/Application/Users/IUserRepository.cs
+++ b/src/Application/Users/IUserRepository.cs
@@ -39,4 +39,9 @@ public interface IUserRepository
     /// <param name="username">The name of the user.</param>
     /// <returns>The user, if it exists.</returns>
     User? Fetch(string username);
+
+    /// <summary>
+    /// Ensures that an admin user is created.
+    /// </summary>
+    void EnsureAdminCreated();
 }

--- a/src/Application/Users/UserService.cs
+++ b/src/Application/Users/UserService.cs
@@ -72,13 +72,23 @@ public class UserService : IUserService
         return _repo.All;
     }
 
+    private static IEnumerable<Claim> CreateClaims(User user)
+    {
+        var claims = new List<Claim> { new("id", user.Id.ToString()), };
+
+        if (user.Name == "admin")
+            claims.Add(new Claim("IsAdmin", "true"));
+
+        return claims;
+    }
+
     private string GenerateJwtToken(User user)
     {
         var tokenHandler = new JwtSecurityTokenHandler();
         byte[] key = Encoding.UTF8.GetBytes(_environmentConfig.JwtSecret);
         var tokenDescriptor = new SecurityTokenDescriptor
         {
-            Subject = new ClaimsIdentity(new[] { new Claim("id", user.Id.ToString()), }),
+            Subject = new ClaimsIdentity(CreateClaims(user)),
             Audience = _config["Jwt:Issuer"],
             Issuer = _config["Jwt:Issuer"],
             Expires = DateTime.UtcNow.AddHours(1),

--- a/src/Application/Users/UserService.cs
+++ b/src/Application/Users/UserService.cs
@@ -30,6 +30,8 @@ public class UserService : IUserService
         _repo = repo;
         _config = config;
         _environmentConfig = environmentConfig;
+
+        _repo.EnsureAdminCreated();
     }
 
     /// <inheritdoc />

--- a/src/Client/Pages/Admin/AdminPage.razor
+++ b/src/Client/Pages/Admin/AdminPage.razor
@@ -19,7 +19,8 @@
         </TabPanel>
         <TabPanel Name="users">
             <UserForm OnUserAdded="AddUserToTable"/>
-            <UserTable @ref="@_userTable"/></TabPanel>
+            <UserTable @ref="@_userTable"/>
+        </TabPanel>
     </Content>
 </Tabs>
 

--- a/src/Client/Pages/Admin/AdminPage.razor
+++ b/src/Client/Pages/Admin/AdminPage.razor
@@ -9,8 +9,8 @@
       Justified="true"
       Pills="true">
     <Items>
-        <Tab Name="contracts">Kontrakt</Tab>
-        <Tab Name="users">Användare</Tab>
+        <Tab Name="contracts">Hantera kontrakt</Tab>
+        <Tab Name="users">Hantera användare</Tab>
     </Items>
     <Content>
         <TabPanel Name="contracts">

--- a/src/Client/Pages/Admin/AdminPage.razor
+++ b/src/Client/Pages/Admin/AdminPage.razor
@@ -4,15 +4,28 @@
 
 <h2>Adminsida</h2>
 
-<ContractForm OnContractUploaded="AddContractToTable"/>
-<hr/>
-<ContractTable @ref="@_contractTable"/>
-<hr/>
-<UserForm OnUserAdded="AddUserToTable"/>
-<hr/>
-<UserTable @ref="@_userTable"/>
+<Tabs SelectedTab="@_selectedTab"
+      SelectedTabChanged="@OnSelectedTabChanged"
+      Justified="true"
+      Pills="true">
+    <Items>
+        <Tab Name="contracts">Kontrakt</Tab>
+        <Tab Name="users">Användare</Tab>
+    </Items>
+    <Content>
+        <TabPanel Name="contracts">
+            <ContractForm OnContractUploaded="AddContractToTable"/>
+            <ContractTable @ref="@_contractTable"/>
+        </TabPanel>
+        <TabPanel Name="users">
+            <UserForm OnUserAdded="AddUserToTable"/>
+            <UserTable @ref="@_userTable"/></TabPanel>
+    </Content>
+</Tabs>
 
 @code {
+
+    private string _selectedTab = "contracts";
 
     private ContractTable _contractTable = null!;
     private UserTable _userTable = null!;
@@ -25,5 +38,11 @@
     private void AddUserToTable(User user)
     {
         _userTable.Add(user);
+    }
+
+    private Task OnSelectedTabChanged(string tabName)
+    {
+        _selectedTab = tabName;
+        return Task.CompletedTask;
     }
 }

--- a/src/Client/Pages/Dashboard/StatusUpdateItem.razor.css
+++ b/src/Client/Pages/Dashboard/StatusUpdateItem.razor.css
@@ -1,4 +1,8 @@
-﻿.oi {
+﻿* {
+    color: var(--prodigo-black);
+}
+
+.oi {
     width: 2rem;
     align-self: baseline;
 }

--- a/src/Client/Shared/LogInButton.razor
+++ b/src/Client/Shared/LogInButton.razor
@@ -1,0 +1,13 @@
+﻿@inject IJSRuntime _js
+
+<button id="login-button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#log-in" @onclick="OnClick">
+    Logga in
+</button>
+
+@code {
+    private async Task OnClick()
+    {
+        // Focuses the username text input element.
+        await _js.InvokeVoidAsync("focusElement", "#username");
+    }
+}

--- a/src/Client/Shared/MainLayout.razor
+++ b/src/Client/Shared/MainLayout.razor
@@ -1,16 +1,18 @@
 ﻿@inherits LayoutComponentBase
 <CascadingValue Value="@_loggedInUser" Name="LoggedInUser">
-    <div class="page">
-        <main>
-            <div class="sticky-top">
-                <NavMenu />
-            </div>
-            <article class="content px-4">
-                @Body
-                <LoginModal OnUserLogInChange="@OnUserLogIn"/>
-            </article>
-        </main>
-    </div>
+    <ThemeProvider Theme="@_theme">
+        <div class="page">
+            <main>
+                <div class="sticky-top">
+                    <NavMenu/>
+                </div>
+                <article class="content px-4">
+                    @Body
+                    <LoginModal OnUserLogInChange="@OnUserLogIn"/>
+                </article>
+            </main>
+        </div>
+    </ThemeProvider>
 </CascadingValue>
 
 @code
@@ -22,4 +24,17 @@
     }
 
     private string? _loggedInUser = string.Empty;
+
+    private readonly Theme _theme = new()
+    {
+        ColorOptions = new ThemeColorOptions
+        {
+            Primary = "#3e4b65",
+            Secondary = "#f7f1f1",
+            Dark = "222939",
+            Info = "#516285",
+            Link = "#dadee8",
+        },
+        IsRounded = false,
+    };
 }

--- a/src/Client/Shared/MainLayout.razor
+++ b/src/Client/Shared/MainLayout.razor
@@ -30,10 +30,11 @@
         ColorOptions = new ThemeColorOptions
         {
             Primary = "#3e4b65",
-            Secondary = "#f7f1f1",
+            Secondary = "#516285",
             Dark = "222939",
-            Info = "#516285",
+            Info = "#ffeeae",
             Link = "#dadee8",
+            Danger = "#3D0F16",
         },
         IsRounded = false,
     };

--- a/src/Client/Shared/MainLayout.razor
+++ b/src/Client/Shared/MainLayout.razor
@@ -36,6 +36,6 @@
             Link = "#dadee8",
             Danger = "#3D0F16",
         },
-        IsRounded = false,
+        IsRounded = true,
     };
 }

--- a/src/Client/Shared/NavMenu.razor
+++ b/src/Client/Shared/NavMenu.razor
@@ -23,13 +23,17 @@
                         </NavLink>
                     </li>
                     <li class="nav-item">
-                        <NavLink class="nav-link" href="admin">
-                            <span class="" aria-hidden="true"></span> Admin
-                        </NavLink>
-                    </li>
-                    <li class="nav-item">
                         <NavLink class="nav-link" href="AboutUs">
                             <span class="" aria-hidden="true"></span> Om oss
+                        </NavLink>
+                    </li>
+                }
+                @if (LoggedInUser == "admin")
+                {
+
+                    <li class="nav-item">
+                        <NavLink class="nav-link" href="admin">
+                            <span class="" aria-hidden="true"></span> Admin
                         </NavLink>
                     </li>
                 }

--- a/src/Client/Shared/NavMenu.razor
+++ b/src/Client/Shared/NavMenu.razor
@@ -31,7 +31,7 @@
                 @if (LoggedInUser == "admin")
                 {
 
-                    <li class="nav-item">
+                    <li id="admin-nav-item" class="nav-item">
                         <NavLink class="nav-link" href="admin">
                             <span class="" aria-hidden="true"></span> Admin
                         </NavLink>

--- a/src/Client/Shared/NavMenu.razor
+++ b/src/Client/Shared/NavMenu.razor
@@ -41,9 +41,7 @@
             <div>
                 @if (LoggedInUser.IsNullOrEmpty())
                 {
-                    <button id="login-button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#log-in">
-                        Logga in
-                    </button>
+                    <LogInButton />
                 }
                 else
                 {

--- a/src/Client/wwwroot/js/interop.js
+++ b/src/Client/wwwroot/js/interop.js
@@ -1,5 +1,10 @@
 ﻿function closeModal(id) {
-    var modalElement = document.querySelector(id)
-    var modal = bootstrap.Modal.getOrCreateInstance(modalElement)
+    const modalElement = document.querySelector(id);
+    const modal = bootstrap.Modal.getOrCreateInstance(modalElement);
     modal.hide();
+}
+
+function focusElement(selector) {
+    const element = document.querySelector(selector);
+    element.focus();
 }

--- a/src/Infrastructure/InjectionExtensions.cs
+++ b/src/Infrastructure/InjectionExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Application.Configuration;
+﻿using System.Diagnostics.CodeAnalysis;
+
+using Application.Configuration;
 using Application.Contracts;
 using Application.Documents;
 using Application.Images;
@@ -22,6 +24,7 @@ namespace Infrastructure;
 /// <summary>
 ///     Injects infrastructure.
 /// </summary>
+[ExcludeFromCodeCoverage]
 public static class InjectionExtensions
 {
     /// <summary>

--- a/src/Infrastructure/InjectionExtensions.cs
+++ b/src/Infrastructure/InjectionExtensions.cs
@@ -54,9 +54,6 @@ public static class InjectionExtensions
 
     private static void ConfigureDatabase(DbContextOptionsBuilder options)
     {
-#if DEBUG
-        _ = options.UseSqlServer("Server=localhost;Database=master;Trusted_Connection=True;");
-#else
         string? dbConnectionstring = Environment.GetEnvironmentVariable(EnvironmentVariableKeys.DbConnectionString);
         if (dbConnectionstring == null)
         {
@@ -65,6 +62,5 @@ public static class InjectionExtensions
         }
 
         _ = options.UseSqlServer(dbConnectionstring);
-#endif
     }
 }

--- a/src/Infrastructure/Users/EFUserRepository.cs
+++ b/src/Infrastructure/Users/EFUserRepository.cs
@@ -14,7 +14,7 @@ namespace Infrastructure.Users;
 /// </summary>
 public sealed class EFUserRepository : DbContext, IUserRepository
 {
-    private const string DefaultUserName = "default-user";
+    private const string AdminUserName = "admin";
 
     private readonly ILogger<EFUserRepository> _logger;
 
@@ -34,8 +34,8 @@ public sealed class EFUserRepository : DbContext, IUserRepository
         // Creates the database if it is not already created.
         _ = Database.EnsureCreated();
 
-        if (!Users.Any(user => user.Name == DefaultUserName))
-            CreateDefaultUser();
+        if (!Users.Any(user => user.Name == AdminUserName))
+            CreateAdmin();
     }
 
     /// <inheritdoc />
@@ -93,17 +93,17 @@ public sealed class EFUserRepository : DbContext, IUserRepository
                         .HasKey(user => user.Id);
     }
 
-    private void CreateDefaultUser()
+    private void CreateAdmin()
     {
-        var defaultUser = new User { Name = DefaultUserName, Company = "Prodigo", LatestPaymentDate = DateTime.MaxValue, };
-        _ = Users.Add(defaultUser);
+        var admin = new User { Name = AdminUserName, Company = "Prodigo", LatestPaymentDate = DateTime.MaxValue, };
+        _ = Users.Add(admin);
         try
         {
             _ = SaveChanges();
         }
         catch (DataException e)
         {
-            _logger.LogError("Could not create default user: {Message}", e.Message);
+            _logger.LogError("Could not create admin: {Message}", e.Message);
         }
     }
 }

--- a/src/Infrastructure/Users/EFUserRepository.cs
+++ b/src/Infrastructure/Users/EFUserRepository.cs
@@ -33,9 +33,6 @@ public sealed class EFUserRepository : DbContext, IUserRepository
 
         // Creates the database if it is not already created.
         _ = Database.EnsureCreated();
-
-        if (!Users.Any(user => user.Name == AdminUserName))
-            CreateAdmin();
     }
 
     /// <inheritdoc />
@@ -84,6 +81,13 @@ public sealed class EFUserRepository : DbContext, IUserRepository
     public User? Fetch(string username)
     {
         return Users.FirstOrDefault(user => user.Name == username);
+    }
+
+    /// <inheritdoc />
+    public void EnsureAdminCreated()
+    {
+        if (!Users.Any(user => user.Name == AdminUserName))
+            CreateAdmin();
     }
 
     /// <inheritdoc />

--- a/src/Server/Controllers/ContractsController.cs
+++ b/src/Server/Controllers/ContractsController.cs
@@ -3,6 +3,7 @@ using Application.Exceptions;
 
 using Domain.Contracts;
 
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.Mvc;
 
@@ -85,6 +86,7 @@ public class ContractsController : BaseApiController<ContractsController>
     /// <returns>The identifier of the stored image.</returns>
     /// <response code="400">The ID of the contract was already taken.</response>
     [HttpPost]
+    [Authorize("AdminOnly")]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public IActionResult CreateContract(Contract contract)
     {

--- a/src/Server/Controllers/ContractsController.cs
+++ b/src/Server/Controllers/ContractsController.cs
@@ -109,6 +109,7 @@ public class ContractsController : BaseApiController<ContractsController>
     /// <param name="id">Id of the contract to be removed.</param>
     /// <returns>If the contract was successfully removed.</returns>
     [HttpDelete("{id:guid}")]
+    [Authorize("AdminOnly")]
     public IActionResult Remove(Guid id)
     {
         return _contracts.Remove(id) ?

--- a/src/Server/Controllers/DocumentsController.cs
+++ b/src/Server/Controllers/DocumentsController.cs
@@ -1,5 +1,6 @@
 ﻿using Application.Documents;
 
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Server.Controllers;
@@ -30,6 +31,7 @@ public class DocumentsController : BaseApiController<DocumentsController>
     /// <response code="400">The uploaded file is not a valid document.</response>
     [HttpPost]
     [Produces("text/plain")]
+    [Authorize("AdminOnly")]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<string>> UploadDocumentAsync()
     {

--- a/src/Server/Controllers/ImagesController.cs
+++ b/src/Server/Controllers/ImagesController.cs
@@ -1,5 +1,6 @@
 ﻿using Application.Images;
 
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Server.Controllers;
@@ -30,6 +31,7 @@ public class ImagesController : BaseApiController<ImagesController>
     /// <response code="400">The uploaded file is not a valid image.</response>
     [HttpPost]
     [Produces("text/plain")]
+    [Authorize("AdminOnly")]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<string>> UploadImageAsync()
     {

--- a/src/Server/Controllers/UsersController.cs
+++ b/src/Server/Controllers/UsersController.cs
@@ -57,6 +57,7 @@ public class UsersController : BaseApiController<UsersController>
     /// <param name="id">Id of the user to be removed.</param>
     /// <returns>If the user was successfully removed.</returns>
     [HttpDelete("{id:guid}")]
+    [Authorize("AdminOnly")]
     public IActionResult Remove(Guid id)
     {
         return _users.Remove(id) ?

--- a/src/Server/Controllers/UsersController.cs
+++ b/src/Server/Controllers/UsersController.cs
@@ -35,7 +35,6 @@ public class UsersController : BaseApiController<UsersController>
     /// <response code="400">The ID of the user was already taken.</response>
     [HttpPost]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [AllowAnonymous] // TODO: should only allow admins
     public IActionResult Create(User user)
     {
         try

--- a/src/Server/Controllers/UsersController.cs
+++ b/src/Server/Controllers/UsersController.cs
@@ -34,6 +34,7 @@ public class UsersController : BaseApiController<UsersController>
     /// <returns>If the user was successfully added.</returns>
     /// <response code="400">The ID of the user was already taken.</response>
     [HttpPost]
+    [Authorize("AdminOnly")]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public IActionResult Create(User user)
     {

--- a/src/Server/Program.cs
+++ b/src/Server/Program.cs
@@ -50,6 +50,7 @@ builder.Services.AddAuthorization(options =>
         new AuthorizationPolicyBuilder()
             .AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme)
             .RequireAuthenticatedUser().Build());
+    options.AddPolicy("AdminOnly", policy => policy.RequireClaim("IsAdmin", "true"));
 });
 
 // Add services to the container.

--- a/src/Server/Program.cs
+++ b/src/Server/Program.cs
@@ -55,10 +55,7 @@ builder.Services.AddAuthorization(options =>
 
 // Add services to the container.
 builder.Services.AddControllersWithViews();
-builder.Services.AddRazorPages(options =>
-{
-    _ = options.Conventions.AllowAnonymousToAreaFolder("root", "/wwwroot").AllowAnonymousToPage("/index.html");
-});
+builder.Services.AddRazorPages();
 builder.Services.AddApplication();
 builder.Services.AddInfrastructure();
 builder.Services.AddSwaggerGen();

--- a/tests/Infrastructure.Tests/Contracts/ContractRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/Contracts/ContractRepositoryTests.cs
@@ -9,6 +9,7 @@ using FluentAssertions.Execution;
 
 namespace Infrastructure.Tests.Contracts;
 
+[Collection("DatabaseTests")]
 public class ContractRepositoryTests : IClassFixture<TestContractDatabaseFixture>
 {
     private readonly IContractRepository _cut;

--- a/tests/Infrastructure.Tests/TestContractDatabaseFixture.cs
+++ b/tests/Infrastructure.Tests/TestContractDatabaseFixture.cs
@@ -11,7 +11,7 @@ namespace Infrastructure.Tests;
 public class TestContractDatabaseFixture
 {
     private const string ConnectionString =
-        @"Server=localhost;Database=master_test_contract;User Id=SA; Password=ASDjk_shd$$jkASKJ19821;";
+        @"Server=localhost;Database=master_test;User Id=SA; Password=ASDjk_shd$$jkASKJ19821;";
 
     private static readonly object _lock = new();
     private static bool _databaseInitialized;
@@ -47,7 +47,7 @@ public class TestContractDatabaseFixture
 
         return new EFContractRepository(
             new DbContextOptionsBuilder<EFContractRepository>()
-                .UseSqlServer(connectionString)
+                .UseSqlServer(connectionString, options => options.EnableRetryOnFailure())
                 .Options,
             Mock.Of<ILogger<EFContractRepository>>());
     }

--- a/tests/Infrastructure.Tests/TestUserDatabaseFixture.cs
+++ b/tests/Infrastructure.Tests/TestUserDatabaseFixture.cs
@@ -11,7 +11,7 @@ namespace Infrastructure.Tests;
 public class TestUserDatabaseFixture
 {
     private const string ConnectionString =
-        @"Server=localhost;Database=master_test_user;User Id=SA; Password=ASDjk_shd$$jkASKJ19821;";
+        @"Server=localhost;Database=master_test;User Id=SA; Password=ASDjk_shd$$jkASKJ19821;";
 
     private static readonly object _lock = new();
     private static bool _databaseInitialized;
@@ -47,7 +47,7 @@ public class TestUserDatabaseFixture
 
         return new EFUserRepository(
             new DbContextOptionsBuilder<EFUserRepository>()
-                .UseSqlServer(connectionString)
+                .UseSqlServer(connectionString, options => options.EnableRetryOnFailure())
                 .Options,
             Mock.Of<ILogger<EFUserRepository>>());
     }

--- a/tests/Infrastructure.Tests/Users/UserRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/Users/UserRepositoryTests.cs
@@ -46,40 +46,40 @@ public class UserRepositoryTests : IClassFixture<TestUserDatabaseFixture>
     }
 
     [Fact]
-    public void AfterCreation_DefaultUserIsCreated_IfNoDefaultUserExistedPreviously()
+    public void AfterCreation_AdminUserIsCreated_IfNoAdminUserExistedPreviously()
     {
         // Arrange
-        const string defaultUsername = "default-user";
-        User? defaultUser = _cut.All.FirstOrDefault(user => user.Name == defaultUsername);
-        if (defaultUser is not null)
-            _cut.Remove(defaultUser.Id);
+        const string adminName = "admin";
+        User? admin = _cut.All.FirstOrDefault(user => user.Name == adminName);
+        if (admin is not null)
+            _cut.Remove(admin.Id);
 
         // Re-create database.
         _cut = _fixture.CreateContext();
 
         // Act
-        bool exists = _cut.Exists(defaultUsername);
+        bool exists = _cut.Exists(adminName);
 
         // Assert
         exists.Should().BeTrue();
     }
 
     [Fact]
-    public void AfterCreation_ThereIsOnlyOneDefaultUser_IfDefaultUserExistedPreviously()
+    public void AfterCreation_ThereIsOnlyOneAdmin_IfAdminExistedPreviously()
     {
         // Arrange
-        const string defaultUsername = "default-user";
-        User? defaultUser = _cut.All.FirstOrDefault(user => user.Name == defaultUsername);
+        const string adminName = "admin";
+        User? admin = _cut.All.FirstOrDefault(user => user.Name == adminName);
 
-        if (defaultUser is null) // Ensure user exists.
-            _cut.Add(new User { Name = defaultUsername, });
+        if (admin is null) // Ensure admin exists.
+            _cut.Add(new User { Name = adminName, });
 
         _cut = _fixture.CreateContext(); // Re-create database.
 
         // Act
-        IEnumerable<User> defaultUsers = _cut.All.Where(user => user.Name == defaultUsername);
+        IEnumerable<User> admins = _cut.All.Where(user => user.Name == adminName);
 
         // Assert
-        defaultUsers.Should().ContainSingle();
+        admins.Should().ContainSingle();
     }
 }

--- a/tests/Infrastructure.Tests/Users/UserRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/Users/UserRepositoryTests.cs
@@ -7,6 +7,7 @@ using Domain.Users;
 
 namespace Infrastructure.Tests.Users;
 
+[Collection("DatabaseTests")]
 public class UserRepositoryTests : IClassFixture<TestUserDatabaseFixture>
 {
     private readonly TestUserDatabaseFixture _fixture;
@@ -16,6 +17,7 @@ public class UserRepositoryTests : IClassFixture<TestUserDatabaseFixture>
     {
         _fixture = fixture;
         _cut = _fixture.CreateContext();
+        _cut.EnsureAdminCreated();
     }
 
     [Fact]
@@ -56,6 +58,7 @@ public class UserRepositoryTests : IClassFixture<TestUserDatabaseFixture>
 
         // Re-create database.
         _cut = _fixture.CreateContext();
+        _cut.EnsureAdminCreated();
 
         // Act
         bool exists = _cut.Exists(adminName);

--- a/tests/Presentation.Tests/Client/Shared/NavMenuTests.cs
+++ b/tests/Presentation.Tests/Client/Shared/NavMenuTests.cs
@@ -31,4 +31,18 @@ public class NavMenuTests : UITestFixture
         // Assert
         cut.Find("#logged-in").Should().NotBeNull();
     }
+
+    [Fact]
+    public void NavMenu_DisplaysAdminNavItem_WhenAdminLoggedIn()
+    {
+        // Arrange
+        static void ParameterBuilder(ComponentParameterCollectionBuilder<NavMenu> parameters) =>
+            parameters.Add(property => property.LoggedInUser, "admin");
+
+        // Act
+        IRenderedComponent<NavMenu> cut = Context.RenderComponent<NavMenu>(ParameterBuilder);
+
+        // Assert
+        cut.Find("#admin-nav-item").Should().NotBeNull();
+    }
 }

--- a/tests/Presentation.Tests/Server/Authentication/AuthIntegrationTests.cs
+++ b/tests/Presentation.Tests/Server/Authentication/AuthIntegrationTests.cs
@@ -15,6 +15,15 @@ public class AuthIntegrationTests : IClassFixture<WebApplicationFactory<Program>
         _client = factory.CreateClient();
     }
 
+    public static IEnumerable<object[]> AdminApiEndpoints =>
+        new List<object[]>
+        {
+            new object[] { HttpMethod.Post, "/api/v1/contracts", },
+            new object[] { HttpMethod.Post, "/api/v1/documents", },
+            new object[] { HttpMethod.Post, "/api/v1/images", },
+            new object[] { HttpMethod.Post, "/api/v1/users", },
+        };
+
     [Theory]
     [InlineData("/api/v1/contracts")]
     [InlineData("/api/v1/users")]
@@ -24,6 +33,22 @@ public class AuthIntegrationTests : IClassFixture<WebApplicationFactory<Program>
 
         // Act
         HttpResponseMessage response = await _client.GetAsync(endpointUrl);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Theory]
+    [MemberData(nameof(AdminApiEndpoints))]
+    public async Task SendToAdminApiEndpoints_ReturnsUnauthorized_WhenTokenForAdminIsNotSpecifiedAsync(
+        HttpMethod method,
+        string endpointUrl)
+    {
+        // Arrange
+        var message = new HttpRequestMessage(method, endpointUrl);
+
+        // Act
+        HttpResponseMessage response = await _client.SendAsync(message);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);

--- a/tests/Presentation.Tests/Server/Authentication/AuthIntegrationTests.cs
+++ b/tests/Presentation.Tests/Server/Authentication/AuthIntegrationTests.cs
@@ -1,6 +1,13 @@
 ﻿using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using System.Threading.Tasks;
+
+using Application.Users;
+
+using Domain.Contracts;
+using Domain.Users;
 
 using Microsoft.AspNetCore.Mvc.Testing;
 
@@ -15,13 +22,11 @@ public class AuthIntegrationTests : IClassFixture<WebApplicationFactory<Program>
         _client = factory.CreateClient();
     }
 
-    public static IEnumerable<object[]> AdminApiEndpoints =>
+    public static IEnumerable<object[]> AdminPostApiEndpoints =>
         new List<object[]>
         {
-            new object[] { HttpMethod.Post, "/api/v1/contracts", },
-            new object[] { HttpMethod.Post, "/api/v1/documents", },
-            new object[] { HttpMethod.Post, "/api/v1/images", },
-            new object[] { HttpMethod.Post, "/api/v1/users", },
+            new object[] { "/api/v1/contracts", JsonContent.Create(new Contract()), },
+            new object[] { "/api/v1/users", JsonContent.Create(new User()), },
         };
 
     [Theory]
@@ -39,18 +44,66 @@ public class AuthIntegrationTests : IClassFixture<WebApplicationFactory<Program>
     }
 
     [Theory]
-    [MemberData(nameof(AdminApiEndpoints))]
-    public async Task SendToAdminApiEndpoints_ReturnsUnauthorized_WhenTokenForAdminIsNotSpecifiedAsync(
-        HttpMethod method,
-        string endpointUrl)
+    [MemberData(nameof(AdminPostApiEndpoints))]
+    public async Task SendToAdminPostApiEndpoints_ReturnsUnauthorized_WhenTokenIsNotSpecifiedAsync(
+        string endpointUrl,
+        HttpContent content)
     {
         // Arrange
-        var message = new HttpRequestMessage(method, endpointUrl);
 
         // Act
-        HttpResponseMessage response = await _client.SendAsync(message);
+        HttpResponseMessage response = await _client.PostAsync(endpointUrl, content);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Theory]
+    [MemberData(nameof(AdminPostApiEndpoints))]
+    public async Task SendToAdminPostApiEndpoints_ReturnsForbidden_WhenUserTokenIsSpecifiedAsync(
+        string endpointUrl,
+        HttpContent content)
+    {
+        // Arrange - authenticate as admin user.
+        HttpResponseMessage authResponseMessage = await _client.PostAsJsonAsync("/api/v1/users/authenticate", "admin");
+        AuthenticateResponse? authResponse =
+            await authResponseMessage.Content.ReadFromJsonAsync<AuthenticateResponse>();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("bearer", authResponse?.Token);
+
+        // Arrange - create normal user.
+        var user = new User();
+        await _client.PostAsJsonAsync("/api/v1/users", user);
+
+        // Arrange - authenticate as normal user.
+        authResponseMessage = await _client.PostAsJsonAsync("/api/v1/users/authenticate", user.Name);
+        authResponse = await authResponseMessage.Content.ReadFromJsonAsync<AuthenticateResponse>();
+
+        // Swap out the admin token for a normal user token.
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("bearer", authResponse?.Token);
+
+        // Act
+        HttpResponseMessage response = await _client.PostAsync(endpointUrl, content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Theory]
+    [MemberData(nameof(AdminPostApiEndpoints))]
+    public async Task SendToAdminApiEndpoints_IsSuccessful_WhenAdminIsAuthenticatedAsync(
+        string endpointUrl,
+        HttpContent content)
+    {
+        // Arrange
+        HttpResponseMessage authResponseMessage = await _client.PostAsJsonAsync("/api/v1/users/authenticate", "admin");
+        AuthenticateResponse? authResponse =
+            await authResponseMessage.Content.ReadFromJsonAsync<AuthenticateResponse>();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("bearer", authResponse?.Token);
+
+        // Act
+        HttpResponseMessage response = await _client.PostAsync(endpointUrl, content);
+
+        // Assert
+        response.Should().BeSuccessful();
     }
 }


### PR DESCRIPTION
## Summary
Separates admin user from normal users by only allowing access to certain API endpoints for admins, and only showing the admin page for the admin.

![chrome_biqp53iEJM](https://user-images.githubusercontent.com/12572888/166660542-6c64b6a3-8924-4b2c-9af8-651d607b560e.gif)

# NOTE TO REVIEWERS:
The list of changed files in this PR are more than what have actually been changed, since this branch was created from the branch for #108. The actual files you should be reviewing are the following, please ignore the rest (this problem will be resolved when we merge #108 into master):
![image](https://user-images.githubusercontent.com/12572888/166660942-f35d0ca6-2b16-4e76-9d70-886579444567.png)


## Definition of done
- [x] All acceptance criteria are completed.
- [x] The code has (at least) 80% branch test coverage.
- [x] All tests pass.
- [ ] The code is reviewed and accepted by (at least) two other team members.
- [x] Views adhere to design style.

Closes #86 
