### PR TITLE
bugfix 129 case sensitive user name login

### DIFF
--- a/src/Infrastructure/Databases/EFDatabaseContext.cs
+++ b/src/Infrastructure/Databases/EFDatabaseContext.cs
@@ -53,5 +53,8 @@ public sealed class EFDatabaseContext : DbContext, IDatabaseContext
     {
         _ = modelBuilder.Entity<User>()
                         .HasKey(user => user.Id);
+        _ = modelBuilder.Entity<User>()
+                        .Property(user => user.Name)
+                        .UseCollation("Finnish_Swedish_CS_AS");
     }
 }

--- a/src/Infrastructure/Migrations/20220512170930_MakeUsernameCaseSensitive.Designer.cs
+++ b/src/Infrastructure/Migrations/20220512170930_MakeUsernameCaseSensitive.Designer.cs
@@ -4,6 +4,7 @@ using Infrastructure.Databases;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(EFDatabaseContext))]
-    partial class EFDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20220512170930_MakeUsernameCaseSensitive")]
+    partial class MakeUsernameCaseSensitive
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Migrations/20220512170930_MakeUsernameCaseSensitive.cs
+++ b/src/Infrastructure/Migrations/20220512170930_MakeUsernameCaseSensitive.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    public partial class MakeUsernameCaseSensitive : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Users",
+                type: "nvarchar(max)",
+                nullable: false,
+                collation: "Finnish_Swedish_CS_AS",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Users",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldCollation: "Finnish_Swedish_CS_AS");
+        }
+    }
+}


### PR DESCRIPTION
The default collation is case-insensitive, so switch it to a case-sensitive one.

![image](https://user-images.githubusercontent.com/12572888/168131315-0ac08076-5c2e-4e2d-b4ea-7364878532c5.png)


Closes #129 
