### PR TITLE
Hotfix api endpoint calls

### DIFF
--- a/src/Client/Pages/Admin/ContractForm.razor
+++ b/src/Client/Pages/Admin/ContractForm.razor
@@ -209,7 +209,7 @@
 
         try
         {
-            HttpResponseMessage response = await _http.PostAsync($"/api/v1/{endPoint}", content);
+            HttpResponseMessage response = await _http.PostAsync($"api/v1/{endPoint}", content);
 
             if (response.IsSuccessStatusCode)
             {
@@ -228,7 +228,7 @@
     {
         string json = JsonConvert.SerializeObject(_contract);
         var content = new StringContent(json, Encoding.UTF8, "application/json");
-        HttpResponseMessage response = await _http.PutAsync($"/api/v1/contracts/{_contract.Id}", content);
+        HttpResponseMessage response = await _http.PutAsync($"api/v1/contracts/{_contract.Id}", content);
         if (response.IsSuccessStatusCode)
         {
             await OnContractUploaded.InvokeAsync(_contract);

--- a/src/Client/Pages/Admin/ContractTable.razor
+++ b/src/Client/Pages/Admin/ContractTable.razor
@@ -3,7 +3,7 @@
 
 <FetchData @ref="_dataFetcher"
            TData="List<Contract>"
-           Url="/api/v1/contracts"
+           Url="api/v1/contracts"
            Context="contracts">
 
     <h4>Dina kontrakt</h4>

--- a/src/Client/Pages/Admin/UserForm.razor
+++ b/src/Client/Pages/Admin/UserForm.razor
@@ -49,7 +49,7 @@
     {
         // Make sure date is in UTC.
         _user.LatestPaymentDate = _user.LatestPaymentDate.ToUniversalTime();
-        HttpResponseMessage response = await _http.PostAsJsonAsync("/api/v1/users", _user);
+        HttpResponseMessage response = await _http.PostAsJsonAsync("api/v1/users", _user);
         if (response.IsSuccessStatusCode)
         {
             await OnUserAdded.InvokeAsync(_user);

--- a/src/Client/Pages/Admin/UserTable.razor
+++ b/src/Client/Pages/Admin/UserTable.razor
@@ -3,7 +3,7 @@
 
 <FetchData @ref="_dataFetcher"
            TData="List<User>"
-           Url="/api/v1/users"
+           Url="api/v1/users"
            Context="users">
 
     <h4>Dina kunder</h4>

--- a/src/Client/Pages/Contracts/ContractCard.razor
+++ b/src/Client/Pages/Contracts/ContractCard.razor
@@ -54,7 +54,7 @@
 
     private async Task AddToRecentlyViewed()
     {
-        HttpResponseMessage response = await _http.PostAsJsonAsync("/api/v1/contracts/recent", Contract);
+        HttpResponseMessage response = await _http.PostAsJsonAsync("api/v1/contracts/recent", Contract);
         if (response.IsSuccessStatusCode)
         {
             await OnViewed.InvokeAsync(Contract);

--- a/src/Client/Pages/Contracts/FavoriteButton.razor
+++ b/src/Client/Pages/Contracts/FavoriteButton.razor
@@ -40,11 +40,12 @@
     /// </summary>
     private bool isFavorite { get; set; }
 
+    /// <inheritdoc />
     protected override async void OnInitialized()
     {
         if (_session.IsAuthenticated)
         {
-            HttpResponseMessage response = await _http.GetAsync($"/api/v1/users/{_session.Username}/favorites/{Contract.Id}");
+            HttpResponseMessage response = await _http.GetAsync($"api/v1/users/{_session.Username}/favorites/{Contract.Id}");
             isFavorite = response.IsSuccessStatusCode;
         }
         else
@@ -52,7 +53,6 @@
             isFavorite = false;
         }
         await InvokeAsync(StateHasChanged);
-        base.OnInitialized();
     }
 
     private async Task ChangeFavorite()
@@ -61,7 +61,7 @@
         {
             FavoriteContractDto favoriteContract = new() { UserName = _session.Username, ContractId = Contract.Id, IsFavorite = !isFavorite };
 
-            HttpResponseMessage response = await _http.PostAsJsonAsync($"/api/v1/users/{_session.Username}/favorites", favoriteContract);
+            HttpResponseMessage response = await _http.PostAsJsonAsync($"api/v1/users/{_session.Username}/favorites", favoriteContract);
             if (response.IsSuccessStatusCode)
             {
                 isFavorite = !isFavorite;

--- a/src/Client/Pages/Contracts/FavoriteButton.razor
+++ b/src/Client/Pages/Contracts/FavoriteButton.razor
@@ -6,7 +6,7 @@
 @inject HttpClient _http
 @inject ISessionService _session
 
-<button class="btn p-0 white-text" @onclick="ChangeFavorite">
+<button id="favorite-button" class="btn p-0 white-text" @onclick="ChangeFavorite">
     @if (isFavorite)
     {
         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-heart-fill" viewBox="0 0 16 16">

--- a/src/Client/Pages/Contracts/RecentlyViewed.razor
+++ b/src/Client/Pages/Contracts/RecentlyViewed.razor
@@ -6,7 +6,7 @@
 @inherits UpdateOnAuthenticateView
 
 <FetchData TData="Contract[]"
-           Url="/api/v1/contracts/recent"
+           Url="api/v1/contracts/recent"
            Context="recents"
            ShouldShowErrors="@_session.IsAuthenticated">
 

--- a/src/Client/Pages/Dashboard/FavoriteCards.razor
+++ b/src/Client/Pages/Dashboard/FavoriteCards.razor
@@ -2,6 +2,7 @@
 @using Newtonsoft.Json
 @inject HttpClient _http
 @inject ISessionService _session
+@inherits UpdateOnAuthenticateView
 
 <div id="favorite-contracts" style="padding-top: 30px;">
     <h3>Favoriter</h3>

--- a/src/Client/Pages/Dashboard/FavoriteCards.razor
+++ b/src/Client/Pages/Dashboard/FavoriteCards.razor
@@ -7,7 +7,7 @@
     <h3>Favoriter</h3>
     <FetchData @ref="_dataFetcher"
                TData="List<Contract>"
-               Url=@($"/api/v1/users/{_session.Username}/favorites")
+               Url=@($"api/v1/users/{_session.Username}/favorites")
                Context="contracts">
         @{
             var contractsList = contracts.ToList();

--- a/src/Client/Shared/FetchData.razor
+++ b/src/Client/Shared/FetchData.razor
@@ -1,7 +1,9 @@
 ﻿@using Newtonsoft.Json
 @using System.Net
+@using JsonException = System.Text.Json.JsonException
 @typeparam TData
 @inject HttpClient _http;
+@inject ILogger<FetchData<TData>> _logger
 @inherits UpdateOnAuthenticateView
 
 @if (_errorMessage is not null && ShouldShowErrors)
@@ -72,7 +74,14 @@ else
             return;
         }
 
-        Data = await response.Content.ReadFromJsonAsync<TData>();
+        try
+        {
+            Data = await response.Content.ReadFromJsonAsync<TData>();
+        }
+        catch (JsonException exception)
+        {
+            _logger.LogError(exception, "Could not deserialize JSON");
+        }
         _errorMessage = null;
         StateHasChanged();
     }

--- a/src/Client/Shared/Login/LoginModal.razor
+++ b/src/Client/Shared/Login/LoginModal.razor
@@ -48,7 +48,7 @@
 
     private async Task ValidateUser()
     {
-        HttpResponseMessage response = await _http.PostAsJsonAsync("/api/v1/users/authenticate", _user);
+        HttpResponseMessage response = await _http.PostAsJsonAsync("api/v1/users/authenticate", _user);
         if (response.IsSuccessStatusCode)
         {
             _logInFailed = false;

--- a/tests/Client.Tests/Pages/Contracts/FavoriteButtonTests.cs
+++ b/tests/Client.Tests/Pages/Contracts/FavoriteButtonTests.cs
@@ -66,7 +66,8 @@ public class FavoriteButtonTests : UITestFixture
 
         bool eventCalled = false;
 
-        MockHttp.When($"/api/v1/users/{userName}/favorites").Respond(req => new HttpResponseMessage(HttpStatusCode.OK));
+        MockHttp.When($"/api/v1/users/{userName}/favorites/{contract.Id}").Respond(req => new HttpResponseMessage(HttpStatusCode.OK));
+        MockHttp.When(HttpMethod.Post, $"/api/v1/users/{userName}/favorites").Respond(HttpStatusCode.OK);
         MockSession.Setup(session => session.Username).Returns(userName);
 
         void ParameterBuilder(ComponentParameterCollectionBuilder<FavoriteButton> parameters) =>

--- a/tests/Client.Tests/Pages/Contracts/FavoriteButtonTests.cs
+++ b/tests/Client.Tests/Pages/Contracts/FavoriteButtonTests.cs
@@ -30,7 +30,7 @@ public class FavoriteButtonTests : UITestFixture
             Context.RenderComponent<FavoriteButton>(ParameterBuilder);
 
         // Assert
-        cut.Find(".bi-heart-fill").Should().NotBeNull();
+        cut.WaitForAssertion(() => cut.Find(".bi-heart-fill").Should().NotBeNull());
         Assert.Throws<ElementNotFoundException>(() => cut.Find(".bi-heart"));
     }
 


### PR DESCRIPTION
API calls were failing when the application was deployed to Azure, because of a redundant `/` in front of our API calls.

I believe this error was caused by a confusion in how these relative endpoints work, so here's a PSA:

Our `HttpClient` instance that we get injected into our client components is configured with a base url, which when we run locally is `https://localhost/` (note the trailing `/`), and when we run on Azure it's `https://prodigoportal.azurewebsites.net/` (also a trailing `/`). This means that the URLs we use in the client to fetch resources shouldn't include this `/` at the beginning:
**incorrect:** `_http.GetAsync("/api/v1/example-endpoint");`
**correct:**: `_http.GetAsync("api/v1/example-endpoint");`.

The *only* place where we need to use a leading `/` is when we're *mocking* URL endpoints *in the tests*:
`MockHttp.When("/api/v1/example-endpoint").RespondJson(...);`


Another API call failure happened when refreshing the dashboard and the favorite cards view would try to fetch favorites for an unauthenticated user, which lead to a deserialization exception. This was solved by making it re-render on authentication state changed and making the FetchData component handle the exception.