### PR TITLE
Bugfix 132 multiple user can have same name

### DIFF
--- a/src/Application/Contracts/IRecentContractRepository.cs
+++ b/src/Application/Contracts/IRecentContractRepository.cs
@@ -10,16 +10,16 @@ public interface IRecentContractRepository
     /// <summary>
     /// Gets the most recent contracts that the user has viewed.
     /// </summary>
-    /// <param name="username">The username of the user.</param>
+    /// <param name="userId">The ID of the user.</param>
     /// <returns>Top most recently viewed contracts.</returns>
-    IList<RecentlyViewedContract> FetchRecentContracts(string username);
+    IList<RecentlyViewedContract> FetchRecentContracts(Guid userId);
 
     /// <summary>
     /// Marks a contract as recently viewed for a user.
     /// </summary>
-    /// <param name="username">The name of the user.</param>
+    /// <param name="userId">The ID of the user.</param>
     /// <param name="contract">Possible new recent contract.</param>
-    void Add(string username, Contract contract);
+    void Add(Guid userId, Contract contract);
 
     /// <summary>
     /// Removes the last viewed contract for user.

--- a/src/Application/Contracts/IRecentContractService.cs
+++ b/src/Application/Contracts/IRecentContractService.cs
@@ -10,21 +10,21 @@ public interface IRecentContractService
     /// <summary>
     /// Gets how many recent contracts there are for a given user.
     /// </summary>
-    /// <param name="username">The name of the user.</param>
+    /// <param name="userId">The ID of the user.</param>
     /// <returns>The number of current recent contracts.</returns>
-    int Size(string username);
+    int Size(Guid userId);
 
     /// <summary>
     /// Gets the most recent contracts that the user has viewed.
     /// </summary>
-    /// <param name="username">The name of the user.</param>
+    /// <param name="userId">The ID of the user.</param>
     /// <returns>Top most recently viewed contracts.</returns>
-    IEnumerable<Contract> FetchRecentContracts(string username);
+    IEnumerable<Contract> FetchRecentContracts(Guid userId);
 
     /// <summary>
     /// Ensures that a new contract is qualified as recently viewed.
     /// </summary>
-    /// <param name="username">The name the user.</param>
+    /// <param name="userId">The ID of the user.</param>
     /// <param name="contract">Possible new recent contract.</param>
-    void Add(string username, Contract contract);
+    void Add(Guid userId, Contract contract);
 }

--- a/src/Application/Contracts/LimitedRecentContractService.cs
+++ b/src/Application/Contracts/LimitedRecentContractService.cs
@@ -21,18 +21,18 @@ public class LimitedRecentContractService : IRecentContractService
     }
 
     /// <inheritdoc />
-    public int Size(string username)
+    public int Size(Guid userId)
     {
-        return _recent.FetchRecentContracts(username).Count;
+        return _recent.FetchRecentContracts(userId).Count;
     }
 
     /// <inheritdoc />
-    public IEnumerable<Contract> FetchRecentContracts(string username)
+    public IEnumerable<Contract> FetchRecentContracts(Guid userId)
     {
         try
         {
             var contracts = new List<Contract>();
-            foreach (RecentlyViewedContract recentContract in _recent.FetchRecentContracts(username)
+            foreach (RecentlyViewedContract recentContract in _recent.FetchRecentContracts(userId)
                          .OrderByDescending(recentContract => recentContract.LastViewed))
             {
                 contracts.Add(_contract.FetchContract(recentContract.ContractId) ??
@@ -48,16 +48,16 @@ public class LimitedRecentContractService : IRecentContractService
     }
 
     /// <inheritdoc />
-    public void Add(string username, Contract contract)
+    public void Add(Guid userId, Contract contract)
     {
-        _recent.Add(username, contract);
+        _recent.Add(userId, contract);
 
         const int recentAmountMax = 3;
-        if (Size(username) <= recentAmountMax)
+        if (Size(userId) <= recentAmountMax)
             return;
 
         RecentlyViewedContract toRemove = _recent
-            .FetchRecentContracts(username)
+            .FetchRecentContracts(userId)
             .OrderBy(recentContract => recentContract.LastViewed)
             .First();
         _recent.Remove(toRemove);

--- a/src/Application/Users/FavoriteContractDto.cs
+++ b/src/Application/Users/FavoriteContractDto.cs
@@ -8,7 +8,7 @@ public class FavoriteContractDto
     /// <summary>
     ///     Gets the id of the user.
     /// </summary>
-    public string UserName { get; init; } = string.Empty;
+    public Guid UserId { get; init; } = Guid.Empty;
 
     /// <summary>
     ///     Gets the id of the contract.

--- a/src/Application/Users/IUserRepository.cs
+++ b/src/Application/Users/IUserRepository.cs
@@ -1,3 +1,4 @@
+using Domain.Contracts;
 using Domain.Users;
 
 namespace Application.Users;
@@ -14,62 +15,55 @@ public interface IUserRepository
     IEnumerable<User> All { get; }
 
     /// <summary>
-    /// Adds a new user to store.
+    /// Adds a new <see cref="User"/> to store.
     /// </summary>
-    /// <param name="user">The new user instance.</param>
+    /// <param name="user">The new <see cref="User"/> instance.</param>
     void Add(User user);
 
     /// <summary>
-    /// Removes the user with the given ID.
+    /// Removes the <see cref="User"/> with the given ID.
     /// </summary>
-    /// <param name="id">The id of the user to be removed.</param>
+    /// <param name="id">The id of the <see cref="User"/> to be removed.</param>
     /// <returns>If the removal was successful.</returns>
     bool Remove(Guid id);
 
     /// <summary>
-    /// Gets the user with the given username if it exists.
+    /// Gets a <see cref="User"/> with the given ID, if it exists.
     /// </summary>
-    /// <param name="username">The name of the user to get.</param>
-    /// <returns>The user, if it exists.</returns>
-    User? Fetch(string username);
+    /// <param name="id">The ID of the <see cref="User"/> to get.</param>
+    /// <returns>The <see cref="User"/>, if it exists.</returns>
+    User? Fetch(Guid id);
 
     /// <summary>
-    /// Checks whether a user exists or not.
+    /// Gets a <see cref="User"/> with the given name, if it exists.
     /// </summary>
-    /// <param name="username">The username to look for.</param>
-    /// <returns>Whether the user exits or not.</returns>
-    bool Exists(string username);
+    /// <param name="username">The name of the <see cref="User"/> to get.</param>
+    /// <returns>The <see cref="User"/>, if it exists.</returns>
+    User? FromName(string username);
 
     /// <summary>
-    /// Ensures that an admin user is created.
+    /// Ensures that an admin <see cref="User"/> is created.
     /// </summary>
     void EnsureAdminCreated();
 
     /// <summary>
-    /// Gets a user with the given id, if it exists.
+    /// Updates a <see cref="User"/>.
     /// </summary>
-    /// <param name="id">The id of the user.</param>
-    /// <returns>The user, if it exists.</returns>
-    User? FetchUser(Guid id);
-
-    /// <summary>
-    /// Updates a user.
-    /// </summary>
-    /// <param name="updatedUser">The updated user.</param>
+    /// <param name="updatedUser">The updated <see cref="User"/>.</param>
     void UpdateUser(User updatedUser);
 
     /// <summary>
-    /// Adds a favorite contract to store, for a certain user.
+    /// Adds a favorite contract to store, for a certain <see cref="User"/>.
     /// </summary>
-    /// <param name="userName">The name of the user.</param>
-    /// <param name="contractId">The id of the contract.</param>
-    void AddFavorite(string userName, Guid contractId);
+    /// <param name="userId">The id of the <see cref="User"/>.</param>
+    /// <param name="contractId">The id of the <see cref="Contract"/>.</param>
+    void AddFavorite(Guid userId, Guid contractId);
 
     /// <summary>
-    /// Removes a stored favorite contract, for a certain user.
+    /// Removes a stored favorite contract, for a certain <see cref="User"/>.
     /// </summary>
-    /// <param name="userName">The name of the user.</param>
+    /// <param name="userId">The id of the <see cref="User"/>.</param>
     /// <param name="contractId">The id of the contract.</param>
     /// <returns>If the removal was successful.</returns>
-    bool RemoveFavorite(string userName, Guid contractId);
+    bool RemoveFavorite(Guid userId, Guid contractId);
 }

--- a/src/Application/Users/IUserService.cs
+++ b/src/Application/Users/IUserService.cs
@@ -41,13 +41,6 @@ public interface IUserService
     bool Remove(Guid id);
 
     /// <summary>
-    /// Checks whether a user exists or not.
-    /// </summary>
-    /// <param name="username">The username to look for.</param>
-    /// <returns>Whether the user exits or not.</returns>
-    bool UserExists(string username);
-
-    /// <summary>
     /// Generates an authentication token for a given user, if valid.
     /// </summary>
     /// <param name="username">The name of the <see cref="User"/> to authenticate.</param>
@@ -58,30 +51,30 @@ public interface IUserService
     /// <summary>
     /// Gets all contracts marked as favorite by a certain user.
     /// </summary>
-    /// <param name="userName">The name of the user.</param>
+    /// <param name="userId">The ID of the user.</param>
     /// <returns>All contracts marked as favorite by the user.</returns>
-    IEnumerable<Contract> FetchAllFavorites(string userName);
+    IEnumerable<Contract> FetchAllFavorites(Guid userId);
 
     /// <summary>
     /// Checks if the contract is marked as favorite by the user.
     /// </summary>
-    /// <param name="userName">The name of the user.</param>
-    /// <param name="contractId">The id of the contract.</param>
+    /// <param name="userId">The ID of the user.</param>
+    /// <param name="contractId">The ID of the contract.</param>
     /// <returns>Whether the contract was marked as favorite.</returns>
-    bool IsFavorite(string userName, Guid contractId);
+    bool IsFavorite(Guid userId, Guid contractId);
 
     /// <summary>
     /// Adds a favorite contract for a certain user.
     /// </summary>
-    /// <param name="userName">The name of the user.</param>
-    /// <param name="contractId">The id of the contract.</param>
-    void AddFavorite(string userName, Guid contractId);
+    /// <param name="userId">The ID of the user.</param>
+    /// <param name="contractId">The ID of the contract.</param>
+    void AddFavorite(Guid userId, Guid contractId);
 
     /// <summary>
     /// Removes a favorite contract for a certain user.
     /// </summary>
-    /// <param name="userName">The name of the user.</param>
-    /// <param name="contractId">The id of the contract.</param>
+    /// <param name="userId">The ID of the user.</param>
+    /// <param name="contractId">The ID of the contract.</param>
     /// <returns>Whether the removal was successful.</returns>
-    bool RemoveFavorite(string userName, Guid contractId);
+    bool RemoveFavorite(Guid userId, Guid contractId);
 }

--- a/src/Application/Users/UserDoesNotExistException.cs
+++ b/src/Application/Users/UserDoesNotExistException.cs
@@ -8,9 +8,9 @@ public class UserDoesNotExistException : Exception
     /// <summary>
     /// Initializes a new instance of the <see cref="UserDoesNotExistException"/> class.
     /// </summary>
-    /// <param name="username">The name of the user that could not be found.</param>
-    public UserDoesNotExistException(string username)
-        : base($"Could not find user with name {username}")
+    /// <param name="userId">The ID of the user that could not be found.</param>
+    public UserDoesNotExistException(Guid userId)
+        : base($"Could not find user with ID {userId}")
     {
     }
 
@@ -24,10 +24,29 @@ public class UserDoesNotExistException : Exception
     /// <summary>
     /// Initializes a new instance of the <see cref="UserDoesNotExistException"/> class.
     /// </summary>
-    /// <param name="username">The name of the user that could not be found.</param>
+    /// <param name="userId">The ID of the user that could not be found.</param>
     /// <param name="innerException">The inner exception.</param>
-    public UserDoesNotExistException(string username, Exception innerException)
-        : base($"Could not find user with name {username}", innerException)
+    public UserDoesNotExistException(Guid userId, Exception innerException)
+        : base($"Could not find user with ID {userId}", innerException)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UserDoesNotExistException"/> class.
+    /// </summary>
+    /// <param name="message">The exception message.</param>
+    public UserDoesNotExistException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UserDoesNotExistException"/> class.
+    /// </summary>
+    /// <param name="message">The exception message.</param>
+    /// <param name="innerException">The inner exception.</param>
+    public UserDoesNotExistException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Application/Users/UserNameTakenException.cs
+++ b/src/Application/Users/UserNameTakenException.cs
@@ -1,0 +1,35 @@
+﻿using Domain.Users;
+
+namespace Application.Users;
+
+/// <summary>
+/// Thrown when the name of a <see cref="User"/> is already taken.
+/// </summary>
+public class UserNameTakenException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UserNameTakenException"/> class.
+    /// </summary>
+    /// <param name="message">The exception message.</param>
+    /// <param name="innerException">The inner exception.</param>
+    public UserNameTakenException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UserNameTakenException"/> class.
+    /// </summary>
+    /// <param name="message">The exception message.</param>
+    public UserNameTakenException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UserNameTakenException"/> class.
+    /// </summary>
+    public UserNameTakenException()
+    {
+    }
+}

--- a/src/Application/Users/UserService.cs
+++ b/src/Application/Users/UserService.cs
@@ -43,21 +43,15 @@ public class UserService : IUserService
     }
 
     /// <inheritdoc />
-    public bool UserExists(string username)
-    {
-        return _repo.Exists(username);
-    }
-
-    /// <inheritdoc />
     public AuthenticateResponse Authenticate(string username, string password)
     {
-        User? user = _repo.Fetch(username);
+        User? user = _repo.FromName(username);
 
         return user is null
             ? throw new UserDoesNotExistException(username)
             : IsPasswordValid(user, password)
                 ? new AuthenticateResponse(user, GenerateJwtToken(user))
-                : throw new InvalidPasswordException("Wrong password.");
+                : throw new InvalidPasswordException();
     }
 
     /// <inheritdoc />
@@ -81,31 +75,31 @@ public class UserService : IUserService
     /// <inheritdoc />
     public User FetchUser(Guid id)
     {
-        return _repo.FetchUser(id) ?? throw new UserDoesNotExistException();
+        return _repo.Fetch(id) ?? throw new UserDoesNotExistException();
     }
 
     /// <inheritdoc />
-    public IEnumerable<Contract> FetchAllFavorites(string userName)
+    public IEnumerable<Contract> FetchAllFavorites(Guid userId)
     {
-        return FetchUser(userName).Favorites;
+        return FetchUser(userId).Favorites;
     }
 
     /// <inheritdoc />
-    public bool IsFavorite(string userName, Guid contractId)
+    public bool IsFavorite(Guid userId, Guid contractId)
     {
-        return FetchUser(userName).Favorites.Any(c => c.Id == contractId);
+        return FetchUser(userId).Favorites.Any(c => c.Id == contractId);
     }
 
     /// <inheritdoc />
-    public void AddFavorite(string userName, Guid contractId)
+    public void AddFavorite(Guid userId, Guid contractId)
     {
-        _repo.AddFavorite(userName, contractId);
+        _repo.AddFavorite(userId, contractId);
     }
 
     /// <inheritdoc />
-    public bool RemoveFavorite(string userName, Guid contractId)
+    public bool RemoveFavorite(Guid userId, Guid contractId)
     {
-        return _repo.RemoveFavorite(userName, contractId);
+        return _repo.RemoveFavorite(userId, contractId);
     }
 
     private static IEnumerable<Claim> CreateClaims(User user)
@@ -138,15 +132,5 @@ public class UserService : IUserService
         };
         SecurityToken? token = tokenHandler.CreateToken(tokenDescriptor);
         return tokenHandler.WriteToken(token);
-    }
-
-    private User FetchUser(string username)
-    {
-        User? user = _repo.Fetch(username);
-
-        if (user == null)
-            throw new UserDoesNotExistException(username);
-
-        return user;
     }
 }

--- a/src/Application/Users/UserService.cs
+++ b/src/Application/Users/UserService.cs
@@ -38,6 +38,9 @@ public class UserService : IUserService
         if (_repo.All.Any(otherUser => user.Id.Equals(otherUser.Id)))
             throw new IdentifierAlreadyTakenException();
 
+        if (_repo.All.Any(otherUser => user.Name.Equals(otherUser.Name, StringComparison.Ordinal)))
+            throw new UserNameTakenException();
+
         user.Password = BCrypt.Net.BCrypt.HashPassword(user.Password);
         _repo.Add(user);
     }

--- a/src/Client/Pages/Contracts/FavoriteButton.razor
+++ b/src/Client/Pages/Contracts/FavoriteButton.razor
@@ -61,9 +61,9 @@
 
     private async Task ChangeFavorite()
     {
-        if (!string.IsNullOrEmpty(Session.Username))
+        if (Session.UserId is not null)
         {
-            FavoriteContractDto favoriteContract = new() { UserName = Session.Username, ContractId = Contract.Id, IsFavorite = !IsFavorite };
+            FavoriteContractDto favoriteContract = new() { UserId = Session.UserId.Value, ContractId = Contract.Id, IsFavorite = !IsFavorite };
 
             HttpResponseMessage response = await Http.PostAsJsonAsync($"api/v1/users/{Session.Username}/favorites", favoriteContract);
             if (response.IsSuccessStatusCode)

--- a/src/Client/Pages/Contracts/FavoriteButton.razor
+++ b/src/Client/Pages/Contracts/FavoriteButton.razor
@@ -44,12 +44,14 @@
     /// </summary>
     private bool IsFavorite { get; set; }
 
+    private string BaseUrl => $"api/v1/users/{Session.UserId}/favorites";
+
     /// <inheritdoc />
     protected override async void OnInitialized()
     {
         if (Session.IsAuthenticated)
         {
-            HttpResponseMessage response = await Http.GetAsync($"api/v1/users/{Session.Username}/favorites/{Contract.Id}");
+            HttpResponseMessage response = await Http.GetAsync($"{BaseUrl}/{Contract.Id}");
             IsFavorite = response.IsSuccessStatusCode;
         }
         else
@@ -65,7 +67,7 @@
         {
             FavoriteContractDto favoriteContract = new() { UserId = Session.UserId.Value, ContractId = Contract.Id, IsFavorite = !IsFavorite };
 
-            HttpResponseMessage response = await Http.PostAsJsonAsync($"api/v1/users/{Session.Username}/favorites", favoriteContract);
+            HttpResponseMessage response = await Http.PostAsJsonAsync(BaseUrl, favoriteContract);
             if (response.IsSuccessStatusCode)
             {
                 IsFavorite = !IsFavorite;

--- a/src/Client/Pages/Contracts/RecentlyViewed.razor
+++ b/src/Client/Pages/Contracts/RecentlyViewed.razor
@@ -5,7 +5,7 @@
 @inject HttpClient _http
 @inject ISessionService _session
 @inherits UpdateOnAuthenticateView
-@if (_session.Username is not (null or ""))
+@if (_session.IsAuthenticated)
 {
     <FetchData @ref="_dataFetcher"
                TData="IEnumerable<Contract>"
@@ -62,7 +62,7 @@
         }
     }
 
-    private string FetchUrl => BaseUrl + _session.Username + UrlRecentSuffix;
+    private string FetchUrl => BaseUrl + _session.UserId + UrlRecentSuffix;
 
 
     /// <summary>

--- a/src/Client/Pages/Dashboard/FavoriteCards.razor
+++ b/src/Client/Pages/Dashboard/FavoriteCards.razor
@@ -8,7 +8,7 @@
     <h3>Favoriter</h3>
     <FetchData @ref="_dataFetcher"
                TData="List<Contract>"
-               Url=@($"api/v1/users/{_session.Username}/favorites")
+               Url=@($"api/v1/users/{_session.UserId}/favorites")
                Context="contracts">
         @{
             var contractsList = contracts.ToList();
@@ -18,7 +18,7 @@
             <div id="favorite-cards-container" class="d-flex flex-row justify-content-around flex-wrap">
                 @foreach (var contract in contractsList)
                 {
-                    <ContractCard Contract=@contract OnFavoriteChange="@((args)=> OnFavoriteChange(((Guid, bool))args))"/>
+                    <ContractCard Contract=@contract OnFavoriteChange="@OnFavoriteChange"/>
                 }
             </div>
         }

--- a/src/Client/Services/Authentication/ISessionService.cs
+++ b/src/Client/Services/Authentication/ISessionService.cs
@@ -23,6 +23,11 @@ public interface ISessionService
     string? Username { get; }
 
     /// <summary>
+    /// Gets the ID of the currently authenticated user, if authenticated.
+    /// </summary>
+    Guid? UserId { get; }
+
+    /// <summary>
     /// Begins a new authenticated user session.
     /// </summary>
     /// <param name="authentication">The authentication used to identify the user.</param>

--- a/src/Client/Services/Authentication/SessionManagerService.cs
+++ b/src/Client/Services/Authentication/SessionManagerService.cs
@@ -40,6 +40,9 @@ internal class SessionManagerService : ISessionService
     public string? Username { get; private set; }
 
     /// <inheritdoc/>
+    public Guid? UserId { get; private set; }
+
+    /// <inheritdoc/>
     public async Task BeginAsync(AuthenticateResponse authentication)
     {
         await _storage.SetItemAsync("user", authentication).ConfigureAwait(true);
@@ -56,6 +59,7 @@ internal class SessionManagerService : ISessionService
 
         IsAuthenticated = false;
         Username = null;
+        UserId = null;
 
         AuthenticationStateChanged?.Invoke(this, new AuthenticationEventArgs { State = null, });
     }
@@ -81,6 +85,7 @@ internal class SessionManagerService : ISessionService
         _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("bearer", authentication.Token);
         IsAuthenticated = true;
         Username = authentication.Username;
+        UserId = authentication.Id;
         AuthenticationStateChanged?.Invoke(this, new AuthenticationEventArgs { State = authentication, });
     }
 }

--- a/src/Infrastructure/Databases/EFRecentContractRepository.cs
+++ b/src/Infrastructure/Databases/EFRecentContractRepository.cs
@@ -35,7 +35,7 @@ public class EFRecentContractRepository : IRecentContractRepository
     /// <inheritdoc />
     public void Add(Guid userId, Contract contract)
     {
-        User? user = Users.Find(userId);
+        User? user = Users.Include(user => user.RecentlyViewContracts).FirstOrDefault(user => user.Id == userId);
         if (user is null)
             throw new UserDoesNotExistException(userId);
 
@@ -77,7 +77,7 @@ public class EFRecentContractRepository : IRecentContractRepository
     /// <inheritdoc />
     public IList<RecentlyViewedContract> FetchRecentContracts(Guid userId)
     {
-        User? user = Users.Find(userId);
+        User? user = Users.Include(user => user.RecentlyViewContracts).FirstOrDefault(user => user.Id == userId);
         if (user is null)
             throw new UserDoesNotExistException(userId);
 

--- a/src/Server/Controllers/FavoritesController.cs
+++ b/src/Server/Controllers/FavoritesController.cs
@@ -9,7 +9,7 @@ namespace Server.Controllers;
 /// WebAPI for favorites.
 /// </summary>
 [ApiController]
-[Route("api/v1/users/{username}/[controller]")]
+[Route("api/v1/users/{userId:guid}/[controller]")]
 public class FavoritesController : BaseApiController<FavoritesController>
 {
     private readonly IUserService _users;

--- a/src/Server/Controllers/FavoritesController.cs
+++ b/src/Server/Controllers/FavoritesController.cs
@@ -38,11 +38,11 @@ public class FavoritesController : BaseApiController<FavoritesController>
         {
             if (favoriteContract.IsFavorite)
             {
-                _users.AddFavorite(favoriteContract.UserName, favoriteContract.ContractId);
+                _users.AddFavorite(favoriteContract.UserId, favoriteContract.ContractId);
             }
             else
             {
-                _ = _users.RemoveFavorite(favoriteContract.UserName, favoriteContract.ContractId);
+                _ = _users.RemoveFavorite(favoriteContract.UserId, favoriteContract.ContractId);
             }
 
             return Ok();
@@ -60,23 +60,23 @@ public class FavoritesController : BaseApiController<FavoritesController>
     /// <summary>
     /// Checks if a certain contract is marked as favorite by a certain user.
     /// </summary>
-    /// <param name="userName">The name of the user.</param>
-    /// <param name="contractId">The id of the contract.</param>
+    /// <param name="userId">The ID of the user.</param>
+    /// <param name="contractId">The ID of the contract.</param>
     /// <returns>Whether the contract is marked as favorite by the user.</returns>
     [HttpGet("{contractId:guid}")]
-    public IActionResult GetIsFavorite(string userName, Guid contractId)
+    public IActionResult GetIsFavorite(Guid userId, Guid contractId)
     {
-        return _users.IsFavorite(userName, contractId) ? Ok() : NotFound();
+        return _users.IsFavorite(userId, contractId) ? Ok() : NotFound();
     }
 
     /// <summary>
     /// Gets all contracts marked as favorite by a certain user.
     /// </summary>
-    /// <param name="userName">The name of the user.</param>
+    /// <param name="userId">The ID of the user.</param>
     /// <returns>All contracts marked as favorite by the user.</returns>
     [HttpGet]
-    public IEnumerable<Contract> GetAll(string userName)
+    public IEnumerable<Contract> GetAll(Guid userId)
     {
-        return _users.FetchAllFavorites(userName);
+        return _users.FetchAllFavorites(userId);
     }
 }

--- a/src/Server/Controllers/RecentsController.cs
+++ b/src/Server/Controllers/RecentsController.cs
@@ -29,25 +29,25 @@ public class RecentsController : BaseApiController<RecentsController>
     /// <summary>
     /// Gets all recently viewed contracts.
     /// </summary>
-    /// <param name="username">The logged in user.</param>
+    /// <param name="userId">The ID of the logged in user.</param>
     /// <returns>All recently viewed contracts.</returns>
     [HttpGet]
-    public IEnumerable<Contract> RecentContracts(string username)
+    public IEnumerable<Contract> RecentContracts(Guid? userId)
     {
-        return username.IsNullOrEmpty() ? new List<Contract>() : _recent.FetchRecentContracts(username);
+        return userId is null ? new List<Contract>() : _recent.FetchRecentContracts(userId.Value);
     }
 
     /// <summary>
     /// Adds a contract as recently viewed.
     /// </summary>
-    /// <param name="username">The logged in user.</param>
+    /// <param name="userId">The ID of the logged in user.</param>
     /// <param name="contract">The contract to add.</param>
     [HttpPost]
-    public void Add(string username, Contract contract)
+    public void Add(Guid userId, Contract contract)
     {
         try
         {
-            _recent.Add(username, contract);
+            _recent.Add(userId, contract);
         }
         catch (UserDoesNotExistException)
         {

--- a/src/Server/Controllers/RecentsController.cs
+++ b/src/Server/Controllers/RecentsController.cs
@@ -10,7 +10,7 @@ namespace Server.Controllers;
 /// WebAPI for recent contracts.
 /// </summary>
 [ApiController]
-[Route("api/v1/users/{username}/[controller]")]
+[Route("api/v1/users/{userId:guid}/[controller]")]
 public class RecentsController : BaseApiController<RecentsController>
 {
     private readonly IRecentContractService _recent;

--- a/src/Server/Controllers/UsersController.cs
+++ b/src/Server/Controllers/UsersController.cs
@@ -51,6 +51,10 @@ public class UsersController : BaseApiController<UsersController>
         {
             _users.UpdateUser(user);
         }
+        catch (UserNameTakenException)
+        {
+            return BadRequest($"Name {user.Name} is already taken");
+        }
 
         return Ok();
     }

--- a/tests/Application.Tests/Contracts/RecentContractServiceTests.cs
+++ b/tests/Application.Tests/Contracts/RecentContractServiceTests.cs
@@ -9,7 +9,7 @@ namespace Application.Tests.Contracts;
 
 public class RecentContractServiceTests
 {
-    private const string UserName = "123";
+    private readonly Guid _userId = Guid.NewGuid();
     private readonly IRecentContractService _cut;
     private readonly Mock<IRecentContractRepository> _mockRecentRepo;
     private readonly Mock<IContractRepository> _mockContractRepo;
@@ -27,11 +27,11 @@ public class RecentContractServiceTests
         // Arrange
         var contract = new Contract();
         var contracts = new List<RecentlyViewedContract> { new(contract.Id, new User().Id) };
-        _mockRecentRepo.Setup(repo => repo.FetchRecentContracts(It.IsAny<string>()))
+        _mockRecentRepo.Setup(repo => repo.FetchRecentContracts(It.IsAny<Guid>()))
             .Returns(contracts);
 
         // Act
-        int size = _cut.Size(UserName);
+        int size = _cut.Size(_userId);
 
         // Assert
         size.Should().Be(1);
@@ -43,14 +43,14 @@ public class RecentContractServiceTests
         // Arrange
         var contract = new Contract();
         var contracts = new List<RecentlyViewedContract> { new RecentlyViewedContract() };
-        _mockRecentRepo.Setup(repo => repo.FetchRecentContracts(It.IsAny<string>()))
+        _mockRecentRepo.Setup(repo => repo.FetchRecentContracts(It.IsAny<Guid>()))
             .Returns(contracts);
 
         // Act
-        _cut.Add(UserName, contract);
+        _cut.Add(_userId, contract);
 
         // Assert
-        _mockRecentRepo.Verify(repo => repo.Add(UserName, contract), Times.Once);
+        _mockRecentRepo.Verify(repo => repo.Add(_userId, contract), Times.Once);
     }
 
     [Fact]
@@ -66,11 +66,11 @@ public class RecentContractServiceTests
             new RecentlyViewedContract(),
         };
 
-        _mockRecentRepo.Setup(repo => repo.FetchRecentContracts(It.IsAny<string>()))
+        _mockRecentRepo.Setup(repo => repo.FetchRecentContracts(It.IsAny<Guid>()))
             .Returns(contracts);
 
         // Act
-        _cut.Add(UserName, contract1);
+        _cut.Add(_userId, contract1);
 
         // Assert
         _mockRecentRepo.Verify(repo => repo.Remove(It.IsAny<RecentlyViewedContract>()), Times.Once);
@@ -89,11 +89,11 @@ public class RecentContractServiceTests
 
         var contracts = new List<RecentlyViewedContract> { recentContract1, recentContract2, recentContract3, };
 
-        _mockRecentRepo.Setup(repo => repo.FetchRecentContracts(It.IsAny<string>()))
+        _mockRecentRepo.Setup(repo => repo.FetchRecentContracts(It.IsAny<Guid>()))
             .Returns(contracts);
 
         // Act
-        _cut.Add(UserName, contract1);
+        _cut.Add(_userId, contract1);
 
         // Assert
         _mockRecentRepo.Verify(repo => repo.Remove(recentContract1), Times.Never);
@@ -113,7 +113,7 @@ public class RecentContractServiceTests
 
         var contracts = new List<RecentlyViewedContract> { recent2, recent3, recent1, };
 
-        _mockRecentRepo.Setup(repo => repo.FetchRecentContracts(It.IsAny<string>()))
+        _mockRecentRepo.Setup(repo => repo.FetchRecentContracts(It.IsAny<Guid>()))
             .Returns(contracts);
 
         _mockContractRepo.Setup(repo => repo.FetchContract(contract1.Id))
@@ -124,7 +124,7 @@ public class RecentContractServiceTests
             .Returns(contract3);
 
         // Act
-        IEnumerable<Contract> recentContracts = _cut.FetchRecentContracts(UserName);
+        IEnumerable<Contract> recentContracts = _cut.FetchRecentContracts(_userId);
 
         // Assert
         recentContracts.SequenceEqual(new List<Contract>() { contract3, contract2, contract1 }).Should().BeTrue();

--- a/tests/Application.Tests/Users/UserServiceFavoriteTests.cs
+++ b/tests/Application.Tests/Users/UserServiceFavoriteTests.cs
@@ -1,14 +1,10 @@
 ﻿using System;
-using System.IdentityModel.Tokens.Jwt;
-using System.Linq;
 
 using Application.Configuration;
-using Application.Exceptions;
 using Application.Users;
+
 using Domain.Contracts;
 using Domain.Users;
-
-using FluentAssertions.Execution;
 
 using Microsoft.Extensions.Configuration;
 
@@ -31,12 +27,12 @@ public class UserServiceFavoriteTests
     public void FetchAll_CallsFetchAllFavoritesFromRepoExactlyOnce()
     {
         // Arrange
-        List<Contract> contracts = new List<Contract>() { new Contract(), new Contract(), new Contract() };
-        var user = new User() { Favorites = contracts };
-        _mockRepo.Setup(repo => repo.Fetch(user.Name)).Returns(user);
+        var contracts = new List<Contract> { new(), new(), new(), };
+        var user = new User { Favorites = contracts, };
+        _mockRepo.Setup(repo => repo.Fetch(user.Id)).Returns(user);
 
         // Act
-        IEnumerable<Contract> fetchedContracts = _cut.FetchAllFavorites(user.Name);
+        IEnumerable<Contract> fetchedContracts = _cut.FetchAllFavorites(user.Id);
 
         // Assert
         fetchedContracts.Should().BeEquivalentTo(contracts);
@@ -50,23 +46,23 @@ public class UserServiceFavoriteTests
         var contract = new Contract();
 
         // Act
-        _cut.AddFavorite(user.Name, contract.Id);
+        _cut.AddFavorite(user.Id, contract.Id);
 
         // Assert
-        _mockRepo.Verify(repo => repo.AddFavorite(user.Name, contract.Id), Times.Once);
+        _mockRepo.Verify(repo => repo.AddFavorite(user.Id, contract.Id), Times.Once);
     }
 
     [Fact]
     public void IsFavorite_ReturnsTrue_IfContractIsMarkedAsFavorite()
     {
         // Arrange
-        Contract contract = new Contract();
-        List<Contract> contracts = new List<Contract>() { contract, new Contract(), new Contract() };
-        var user = new User() { Favorites = contracts };
-        _mockRepo.Setup(repository => repository.Fetch(user.Name)).Returns(user);
+        var contract = new Contract();
+        var contracts = new List<Contract> { contract, new(), new(), };
+        var user = new User { Favorites = contracts, };
+        _mockRepo.Setup(repository => repository.Fetch(user.Id)).Returns(user);
 
         // Act
-        bool actual = _cut.IsFavorite(user.Name, contract.Id);
+        bool actual = _cut.IsFavorite(user.Id, contract.Id);
 
         // Assert
         actual.Should().BeTrue();
@@ -76,13 +72,13 @@ public class UserServiceFavoriteTests
     public void IsFavorite_ReturnsFalse_IfContractIsNotMarkedAsFavorite()
     {
         // Arrange
-        Contract contract = new Contract();
-        List<Contract> contracts = new List<Contract>() { new Contract(), new Contract(), new Contract() };
-        var user = new User() { Favorites = contracts };
-        _mockRepo.Setup(repository => repository.Fetch(user.Name)).Returns(user);
+        var contract = new Contract();
+        var contracts = new List<Contract> { new(), new(), new(), };
+        var user = new User { Favorites = contracts, };
+        _mockRepo.Setup(repository => repository.Fetch(user.Id)).Returns(user);
 
         // Act
-        bool actual = _cut.IsFavorite(user.Name, contract.Id);
+        bool actual = _cut.IsFavorite(user.Id, contract.Id);
 
         // Assert
         actual.Should().BeFalse();
@@ -93,11 +89,11 @@ public class UserServiceFavoriteTests
     {
         // Arrange
         List<Contract> mockFavoriteContracts = new Faker<Contract>().Generate(5);
-        var user = new User() { Favorites = mockFavoriteContracts };
-        _mockRepo.Setup(repository => repository.Fetch(user.Name)).Returns(user);
+        var user = new User { Favorites = mockFavoriteContracts, };
+        _mockRepo.Setup(repository => repository.Fetch(user.Id)).Returns(user);
 
         // Act
-        IEnumerable<Contract> favoriteContracts = _cut.FetchAllFavorites(user.Name);
+        IEnumerable<Contract> favoriteContracts = _cut.FetchAllFavorites(user.Id);
 
         // Assert
         favoriteContracts.Should().BeEquivalentTo(mockFavoriteContracts);
@@ -108,11 +104,11 @@ public class UserServiceFavoriteTests
     {
         // Arrange
         List<Contract> mockFavoriteContracts = new Faker<Contract>().Generate(5);
-        var user = new User() { Favorites = mockFavoriteContracts };
-        _mockRepo.Setup(repository => repository.Fetch(user.Name)).Returns<User?>(null);
+        var user = new User { Favorites = mockFavoriteContracts, };
+        _mockRepo.Setup(repository => repository.Fetch(user.Id)).Returns<User?>(null);
 
         // Act
-        Action add = () => _cut.FetchAllFavorites(user.Name);
+        Action add = () => _cut.FetchAllFavorites(user.Id);
 
         // Assert
         add.Should().Throw<UserDoesNotExistException>();
@@ -124,10 +120,10 @@ public class UserServiceFavoriteTests
         // Arrange
         var user = new User();
         var contract = new Contract();
-        _mockRepo.Setup(repository => repository.RemoveFavorite(user.Name, contract.Id)).Returns(true);
+        _mockRepo.Setup(repository => repository.RemoveFavorite(user.Id, contract.Id)).Returns(true);
 
         // Act
-        bool actual = _cut.RemoveFavorite(user.Name, contract.Id);
+        bool actual = _cut.RemoveFavorite(user.Id, contract.Id);
 
         // Assert
         actual.Should().BeTrue();
@@ -139,10 +135,10 @@ public class UserServiceFavoriteTests
         // Arrange
         var user = new User();
         var contract = new Contract();
-        _mockRepo.Setup(repository => repository.RemoveFavorite(user.Name, contract.Id)).Returns(false);
+        _mockRepo.Setup(repository => repository.RemoveFavorite(user.Id, contract.Id)).Returns(false);
 
         // Act
-        bool actual = _cut.RemoveFavorite(user.Name, contract.Id);
+        bool actual = _cut.RemoveFavorite(user.Id, contract.Id);
 
         // Assert
         actual.Should().BeFalse();

--- a/tests/Application.Tests/Users/UserServiceTests.cs
+++ b/tests/Application.Tests/Users/UserServiceTests.cs
@@ -69,6 +69,20 @@ public class UserServiceTests
     }
 
     [Fact]
+    public void AddingUser_Throws_WhenUserWithNameAlreadyExists()
+    {
+        // Arrange
+        const string name = "A user's name";
+        _mockRepo.Setup(repository => repository.All).Returns(new[] { new User { Name = name, }, });
+
+        // Act
+        Action add = () => _cut.Add(new User { Name = name, });
+
+        // Assert
+        add.Should().Throw<UserNameTakenException>();
+    }
+
+    [Fact]
     public void RemovingUser_DoesReturnTrue_WhenAUserExists()
     {
         // Arrange

--- a/tests/Application.Tests/Users/UserServiceTests.cs
+++ b/tests/Application.Tests/Users/UserServiceTests.cs
@@ -119,7 +119,8 @@ public class UserServiceTests
         const string password = "UserPassword";
         string passwordHash = BCrypt.Net.BCrypt.HashPassword(password);
         var user = new User() { Password = passwordHash, };
-        _mockRepo.Setup(repository => repository.Fetch(user.Name)).Returns(user);
+        _mockRepo.Setup(repository => repository.Fetch(user.Id)).Returns(user);
+        _mockRepo.Setup(repository => repository.FromName(user.Name)).Returns(user);
 
         // Act
         AuthenticateResponse authResponse = _cut.Authenticate(user.Name, password);
@@ -135,42 +136,15 @@ public class UserServiceTests
         const string correctPassword = "CorrectPassword";
         const string incorrectPassword = "IncorrectPassword";
         string passwordHash1 = BCrypt.Net.BCrypt.HashPassword(correctPassword);
-        var user = new User() { Name = "User1", Password = passwordHash1, };
-        _mockRepo.Setup(repository => repository.Fetch(user.Name)).Returns(user);
+        var user = new User { Name = "User1", Password = passwordHash1, };
+        _mockRepo.Setup(repository => repository.Fetch(user.Id)).Returns(user);
+        _mockRepo.Setup(repository => repository.FromName(user.Name)).Returns(user);
 
         // Act
         Action tryAuthenticate = () => _cut.Authenticate(user.Name, incorrectPassword);
 
         // Assert
         tryAuthenticate.Should().Throw<InvalidPasswordException>();
-    }
-
-    [Fact]
-    public void UserExists_ReturnsTrue_IfUserExistsInRepository()
-    {
-        // Arrange
-        string username = "user";
-        _mockRepo.Setup(repository => repository.Exists(username)).Returns(true);
-
-        // Act
-        bool actual = _cut.UserExists(username);
-
-        // Assert
-        actual.Should().BeTrue();
-    }
-
-    [Fact]
-    public void UserExists_ReturnsFalse_IfUserDoesNotExistInRepository()
-    {
-        // Arrange
-        string username = "user";
-        _mockRepo.Setup(repository => repository.Exists(username)).Returns(false);
-
-        // Act
-        bool actual = _cut.UserExists(username);
-
-        // Assert
-        actual.Should().BeFalse();
     }
 
     [Fact]
@@ -225,7 +199,8 @@ public class UserServiceTests
         const string password = "password";
         string passwordHash = BCrypt.Net.BCrypt.HashPassword(password);
         var user = new User { Name = username, Password = passwordHash, };
-        _mockRepo.Setup(repository => repository.Fetch(username)).Returns(user);
+        _mockRepo.Setup(repository => repository.Fetch(user.Id)).Returns(user);
+        _mockRepo.Setup(repository => repository.FromName(user.Name)).Returns(user);
 
         // Act
         AuthenticateResponse authResponse = _cut.Authenticate(username, password);

--- a/tests/Client.Tests/Pages/Contracts/FavoriteButtonTests.cs
+++ b/tests/Client.Tests/Pages/Contracts/FavoriteButtonTests.cs
@@ -21,14 +21,14 @@ public class FavoriteButtonTests : UITestFixture
     public void ContractCard_ShowsFavoriteIcon_WhenContractIsFavoriteMarked()
     {
         // Arrange
-        string userName = "user";
+        var userId = Guid.NewGuid();
         Contract contract = new();
 
         void ParameterBuilder(ComponentParameterCollectionBuilder<FavoriteButton> parameters) =>
             parameters.Add(property => property.Contract, contract);
 
-        MockHttp.When($"/api/v1/users/{userName}/favorites/{contract.Id}").Respond(req => new HttpResponseMessage(HttpStatusCode.OK));
-        MockSession.Setup(session => session.Username).Returns(userName);
+        MockHttp.When($"/api/v1/users/{userId}/favorites/{contract.Id}").Respond(req => new HttpResponseMessage(HttpStatusCode.OK));
+        MockSession.Setup(session => session.UserId).Returns(userId);
 
         // Act
         IRenderedComponent<FavoriteButton> cut =
@@ -44,14 +44,14 @@ public class FavoriteButtonTests : UITestFixture
     public void ContractCard_ShowsNonFavoriteIcon_WhenContractIsNotFavoriteMarked()
     {
         // Arrange
-        string userName = "user";
+        var userId = Guid.NewGuid();
         Contract contract = new();
 
         void ParameterBuilder(ComponentParameterCollectionBuilder<FavoriteButton> parameters) =>
             parameters.Add(property => property.Contract, contract);
 
-        MockHttp.When($"/api/v1/users/{userName}/favorites/{contract.Id}").Respond(req => new HttpResponseMessage(HttpStatusCode.NotFound));
-        MockSession.Setup(session => session.Username).Returns(userName);
+        MockHttp.When($"/api/v1/users/{userId}/favorites/{contract.Id}").Respond(req => new HttpResponseMessage(HttpStatusCode.NotFound));
+        MockSession.Setup(session => session.UserId).Returns(userId);
 
         // Act
         IRenderedComponent<FavoriteButton> cut =
@@ -68,14 +68,14 @@ public class FavoriteButtonTests : UITestFixture
     public async Task FavoriteButton_CallsOnFavoriteChange_WhenClickedAsync()
     {
         // Arrange
-        string userName = "user";
+        var userId = Guid.NewGuid();
         Contract contract = new();
 
         bool eventCalled = false;
 
-        MockHttp.When($"/api/v1/users/{userName}/favorites/{contract.Id}").Respond(req => new HttpResponseMessage(HttpStatusCode.OK));
-        MockHttp.When(HttpMethod.Post, $"/api/v1/users/{userName}/favorites").Respond(HttpStatusCode.OK);
-        MockSession.Setup(session => session.Username).Returns(userName);
+        MockHttp.When($"/api/v1/users/{userId}/favorites/{contract.Id}").Respond(req => new HttpResponseMessage(HttpStatusCode.OK));
+        MockHttp.When(HttpMethod.Post, $"/api/v1/users/{userId}/favorites").Respond(HttpStatusCode.OK);
+        MockSession.Setup(session => session.UserId).Returns(userId);
 
         void ParameterBuilder(ComponentParameterCollectionBuilder<FavoriteButton> parameters) =>
                       parameters.Add(property => property.Contract, contract)
@@ -96,12 +96,12 @@ public class FavoriteButtonTests : UITestFixture
     public void FavoriteButton_DoesNotChangeAppearance_WhenRequestFailed()
     {
         // Arrange
-        string userName = "user";
+        var userId = Guid.NewGuid();
         Contract contract = new();
 
-        MockHttp.When($"/api/v1/users/{userName}/favorites/{contract.Id}").Respond(HttpStatusCode.OK); // Check whether the contract is marked as favorite and receive that it is
-        MockHttp.When(HttpMethod.Post, $"/api/v1/users/{userName}/favorites").Respond(HttpStatusCode.BadRequest); // Post a request to unmark the contract as a favorite and receive that it was not unmarked
-        MockSession.Setup(session => session.Username).Returns(userName);
+        MockHttp.When($"/api/v1/users/{userId}/favorites/{contract.Id}").Respond(HttpStatusCode.OK); // Check whether the contract is marked as favorite and receive that it is
+        MockHttp.When(HttpMethod.Post, $"/api/v1/users/{userId}/favorites").Respond(HttpStatusCode.BadRequest); // Post a request to unmark the contract as a favorite and receive that it was not unmarked
+        MockSession.Setup(session => session.UserId).Returns(userId);
 
         void ParameterBuilder(ComponentParameterCollectionBuilder<FavoriteButton> parameters) =>
                       parameters.Add(property => property.Contract, contract);
@@ -126,12 +126,12 @@ public class FavoriteButtonTests : UITestFixture
     public void FavoriteButton_ChangesAppearance_WhenRequestSucceeds()
     {
         // Arrange
-        string userName = "user";
+        var userId = Guid.NewGuid();
         Contract contract = new();
 
-        MockHttp.When($"/api/v1/users/{userName}/favorites/{contract.Id}").Respond(req => new HttpResponseMessage(HttpStatusCode.OK)); // Check whether the contract is marked as favorite and receive that it is
-        MockHttp.When(HttpMethod.Post, $"/api/v1/users/{userName}/favorites").Respond(req => new HttpResponseMessage(HttpStatusCode.OK)); // Post a request to unmark the contract as a favorite and receive that is was
-        MockSession.Setup(session => session.Username).Returns(userName);
+        MockHttp.When($"/api/v1/users/{userId}/favorites/{contract.Id}").Respond(req => new HttpResponseMessage(HttpStatusCode.OK)); // Check whether the contract is marked as favorite and receive that it is
+        MockHttp.When(HttpMethod.Post, $"/api/v1/users/{userId}/favorites").Respond(req => new HttpResponseMessage(HttpStatusCode.OK)); // Post a request to unmark the contract as a favorite and receive that is was
+        MockSession.Setup(session => session.UserId).Returns(userId);
 
         void ParameterBuilder(ComponentParameterCollectionBuilder<FavoriteButton> parameters) =>
             parameters.Add(property => property.Contract, contract);

--- a/tests/Client.Tests/Pages/Contracts/RecentlyViewedTests.cs
+++ b/tests/Client.Tests/Pages/Contracts/RecentlyViewedTests.cs
@@ -15,11 +15,11 @@ public class RecentlyViewedTests : UITestFixture
     public void RecentlyViewedComponent_ShouldSayNothing_WhenUserIsNotLoggedIn()
     {
         // Arrange
-        const string username = "";
+        var userId = Guid.Empty;
         const string name = "SJ";
         var contract = new Contract() { Name = name };
-        MockSession.Setup(session => session.Username).Returns(username);
-        MockHttp.When($"/api/v1/users/{username}/recents").RespondJson(new[] { contract });
+        MockSession.Setup(session => session.IsAuthenticated).Returns(false);
+        MockHttp.When($"/api/v1/users/{userId}/recents").RespondJson(new[] { contract });
 
         // Act
         IRenderedComponent<RecentlyViewed> cut = Context.RenderComponent<RecentlyViewed>();
@@ -32,9 +32,9 @@ public class RecentlyViewedTests : UITestFixture
     public void RecentlyViewedComponent_ShouldSayNothing_WhenThereAreNoRecentlyViewed()
     {
         // Arrange
-        const string username = "test";
-        MockSession.Setup(session => session.Username).Returns(username);
-        MockHttp.When($"/api/v1/users/{username}/recents").RespondJson(Array.Empty<object>());
+        var userId = Guid.NewGuid();
+        MockSession.Setup(session => session.UserId).Returns(userId);
+        MockHttp.When($"/api/v1/users/{userId}/recents").RespondJson(Array.Empty<object>());
 
         // Act
         IRenderedComponent<RecentlyViewed> cut = Context.RenderComponent<RecentlyViewed>();
@@ -44,14 +44,15 @@ public class RecentlyViewedTests : UITestFixture
     }
 
     [Fact]
-    public void RecentlyViewedComponent_ShouldShowContract_WhenThereAreAtLeastOneRecent()
+    public void RecentlyViewedComponent_ShouldShowContract_WhenThereIsAtLeastOneRecent()
     {
         // Arrange
-        const string userName = "user";
+        var userId = Guid.NewGuid();
         const string name = "SJ";
         var contract = new Contract() { Name = name };
-        MockHttp.When($"/api/v1/users/{userName}/recents").RespondJson(new[] { contract });
-        MockSession.Setup(session => session.Username).Returns(userName);
+        MockHttp.When($"/api/v1/users/{userId}/recents").RespondJson(new[] { contract });
+        MockSession.Setup(session => session.UserId).Returns(userId);
+        MockSession.Setup(session => session.IsAuthenticated).Returns(true);
 
         // Act
         IRenderedComponent<RecentlyViewed> cut = Context.RenderComponent<RecentlyViewed>();

--- a/tests/Client.Tests/Pages/Dashboard/FavoriteCardsTests.cs
+++ b/tests/Client.Tests/Pages/Dashboard/FavoriteCardsTests.cs
@@ -16,10 +16,10 @@ public class FavoriteCardsTests : UITestFixture
     {
         // Arrange
         const string name = "SJ";
-        const string userName = "user";
+        var userId = Guid.NewGuid();
         var contract = new Contract() { Name = name, };
-        MockHttp.When($"/api/v1/users/{userName}/favorites").RespondJson(new[] { contract, });
-        MockSession.Setup(session => session.Username).Returns(userName);
+        MockHttp.When($"/api/v1/users/{userId}/favorites").RespondJson(new[] { contract, });
+        MockSession.Setup(session => session.UserId).Returns(userId);
 
         // Act
         IRenderedComponent<FavoriteCards> cut = Context.RenderComponent<FavoriteCards>();
@@ -32,9 +32,9 @@ public class FavoriteCardsTests : UITestFixture
     [Fact]
     public void ShowNoFavoriteMessage_WhenThereAreNoFavorites()
     {
-        const string userName = "user";
-        MockHttp.When($"/api/v1/users/{userName}/favorites").RespondJson(Array.Empty<Contract>());
-        MockSession.Setup(session => session.Username).Returns(userName);
+        var userId = Guid.NewGuid();
+        MockHttp.When($"/api/v1/users/{userId}/favorites").RespondJson(Array.Empty<Contract>());
+        MockSession.Setup(session => session.UserId).Returns(userId);
 
         // Act
         IRenderedComponent<FavoriteCards> cut = Context.RenderComponent<FavoriteCards>();

--- a/tests/Infrastructure.Tests/Contracts/RecentContractRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/Contracts/RecentContractRepositoryTests.cs
@@ -31,10 +31,10 @@ public class RecentContractRepositoryTests : IClassFixture<TestDatabaseFixture>,
 
         var contract1 = new Contract() { Name = "1" };
         _context.Contracts.Add(contract1);
-        _cut.Add(user1.Name, contract1);
+        _cut.Add(user1.Id, contract1);
 
         // Act
-        IList<RecentlyViewedContract> contracts = _cut.FetchRecentContracts(user1.Name);
+        IList<RecentlyViewedContract> contracts = _cut.FetchRecentContracts(user1.Id);
 
         // Assert
         contracts.First().ContractId.Should().Be(contract1.Id);
@@ -51,12 +51,12 @@ public class RecentContractRepositoryTests : IClassFixture<TestDatabaseFixture>,
         AddContractsToContext(contract1);
 
         // Act
-        _cut.Add(user1.Name, contract1);
-        var timeBeforeReAdd = _context.Users.First(user => user.Name == user1.Name).RecentlyViewContracts
+        _cut.Add(user1.Id, contract1);
+        var timeBeforeReAdd = _context.Users.First(user => user.Id == user1.Id).RecentlyViewContracts
             .First(recentContract => recentContract.ContractId == contract1.Id)
             .LastViewed;
-        _cut.Add(user1.Name, contract1);
-        var timeAfterReAdd = _context.Users.First(user => user.Name == user1.Name).RecentlyViewContracts
+        _cut.Add(user1.Id, contract1);
+        var timeAfterReAdd = _context.Users.First(user => user.Id == user1.Id).RecentlyViewContracts
             .First(recentContract => recentContract.ContractId == contract1.Id)
             .LastViewed;
 
@@ -74,15 +74,15 @@ public class RecentContractRepositoryTests : IClassFixture<TestDatabaseFixture>,
         var contract1 = new Contract();
         var contract2 = new Contract();
         AddContractsToContext(contract1, contract2);
-        _cut.Add(user1.Name, contract1);
-        _cut.Add(user1.Name, contract2);
+        _cut.Add(user1.Id, contract1);
+        _cut.Add(user1.Id, contract2);
 
-        RecentlyViewedContract toRemove = _context.Users.First(user => user.Name == user1.Name).RecentlyViewContracts
+        RecentlyViewedContract toRemove = _context.Users.First(user => user.Id == user1.Id).RecentlyViewContracts
             .First(recentContract => recentContract.ContractId == contract1.Id);
 
         // Act
         _cut.Remove(toRemove);
-        IList<RecentlyViewedContract> contracts = _cut.FetchRecentContracts(user1.Name);
+        IList<RecentlyViewedContract> contracts = _cut.FetchRecentContracts(user1.Id);
 
         // Assert
         contracts.First().ContractId.Should().Be(contract2.Id);
@@ -99,16 +99,16 @@ public class RecentContractRepositoryTests : IClassFixture<TestDatabaseFixture>,
 
         var contract1 = new Contract();
         AddContractsToContext(contract1);
-        _cut.Add(user1.Name, contract1);
-        _cut.Add(user2.Name, contract1);
+        _cut.Add(user1.Id, contract1);
+        _cut.Add(user2.Id, contract1);
 
         // Act
         _context.Contracts.Remove(contract1);
         _context.SaveChanges();
 
         // Assert
-        _context.Users.First(user => user.Name == user1.Name).RecentlyViewContracts.Should().BeEmpty();
-        _context.Users.First(user => user.Name == user2.Name).RecentlyViewContracts.Should().BeEmpty();
+        _context.Users.First(user => user.Id == user1.Id).RecentlyViewContracts.Should().BeEmpty();
+        _context.Users.First(user => user.Id == user2.Id).RecentlyViewContracts.Should().BeEmpty();
     }
 
     [Fact]
@@ -121,13 +121,13 @@ public class RecentContractRepositoryTests : IClassFixture<TestDatabaseFixture>,
         var contract2 = new Contract();
         AddContractsToContext(contract1);
         AddContractsToContext(contract2);
-        _cut.Add(user1.Name, contract1);
+        _cut.Add(user1.Id, contract1);
 
         // Act
         _context.Contracts.Remove(contract2);
         _context.SaveChanges();
 
-        _context.Users.First(user => user.Name == user1.Name).RecentlyViewContracts.Should().ContainSingle();
+        _context.Users.First(user => user.Id == user1.Id).RecentlyViewContracts.Should().ContainSingle();
     }
 
     [Fact]
@@ -137,7 +137,7 @@ public class RecentContractRepositoryTests : IClassFixture<TestDatabaseFixture>,
         var user1 = new User();
 
         // Act
-        Action fetch = () => _cut.FetchRecentContracts(user1.Name);
+        Action fetch = () => _cut.FetchRecentContracts(user1.Id);
 
         // Assert
         fetch.Should().Throw<UserDoesNotExistException>();

--- a/tests/Infrastructure.Tests/Users/UserRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/Users/UserRepositoryTests.cs
@@ -74,7 +74,7 @@ public class UserRepositoryTests : IClassFixture<TestDatabaseFixture>
         _cut.EnsureAdminCreated();
 
         // Act
-        bool exists = _cut.Exists(adminName);
+        bool exists = _cut.FromName(adminName) is not null;
 
         // Assert
         exists.Should().BeTrue();

--- a/tests/Server.Tests/Authentication/AuthenticationTests.cs
+++ b/tests/Server.Tests/Authentication/AuthenticationTests.cs
@@ -32,7 +32,8 @@ public class AuthenticationTests
         string passwordHash = BCrypt.Net.BCrypt.HashPassword(password);
         var user = new User { Name = "user name", Password = passwordHash, };
         var userInfo = new User() { Name = "user name", Password = password, };
-        _mockRepo.Setup(repo => repo.Fetch(user.Name)).Returns(user);
+        _mockRepo.Setup(repo => repo.Fetch(user.Id)).Returns(user);
+        _mockRepo.Setup(repo => repo.FromName(user.Name)).Returns(user);
 
         // Act
         IActionResult result = _cut.Authenticate(userInfo);

--- a/tests/Server.Tests/Controllers/FavoritesControllerTests.cs
+++ b/tests/Server.Tests/Controllers/FavoritesControllerTests.cs
@@ -1,6 +1,8 @@
 using Application.Contracts;
 using Application.Users;
 using Domain.Contracts;
+using Domain.Users;
+
 using Microsoft.AspNetCore.Mvc;
 
 namespace Server.Tests.Controllers;
@@ -20,12 +22,12 @@ public class FavoritesControllerTests
     public void GetAll_ReturnsAllFavoriteContracts()
     {
         // Arrange
-        string userName = "user";
+        var user = new User();
         List<Contract> fakeFavoriteContracts = new Faker<Contract>().Generate(10);
-        _mockContracts.Setup(service => service.FetchAllFavorites(userName)).Returns(fakeFavoriteContracts);
+        _mockContracts.Setup(service => service.FetchAllFavorites(user.Id)).Returns(fakeFavoriteContracts);
 
         // Act
-        IEnumerable<Contract> favoriteContracts = _cut.GetAll(userName);
+        IEnumerable<Contract> favoriteContracts = _cut.GetAll(user.Id);
 
         // Assert
         favoriteContracts.Should().BeEquivalentTo(fakeFavoriteContracts);
@@ -37,7 +39,7 @@ public class FavoritesControllerTests
         // Arrange
         var favoriteContractDto = new FavoriteContractDto()
         {
-            UserName = "user", ContractId = Guid.NewGuid(), IsFavorite = true,
+            UserId = Guid.NewGuid(), ContractId = Guid.NewGuid(), IsFavorite = true,
         };
 
         // Act
@@ -53,9 +55,9 @@ public class FavoritesControllerTests
         // Arrange
         var favoriteContractDto = new FavoriteContractDto()
         {
-            UserName = "user", ContractId = Guid.NewGuid(), IsFavorite = true,
+            UserId = Guid.NewGuid(), ContractId = Guid.NewGuid(), IsFavorite = true,
         };
-        _mockContracts.Setup(service => service.AddFavorite(favoriteContractDto.UserName, favoriteContractDto.ContractId))
+        _mockContracts.Setup(service => service.AddFavorite(favoriteContractDto.UserId, favoriteContractDto.ContractId))
             .Throws<UserDoesNotExistException>();
 
         // Act
@@ -71,9 +73,9 @@ public class FavoritesControllerTests
         // Arrange
         var favoriteContractDto = new FavoriteContractDto()
         {
-            UserName = "user", ContractId = Guid.NewGuid(), IsFavorite = true,
+            UserId = Guid.NewGuid(), ContractId = Guid.NewGuid(), IsFavorite = true,
         };
-        _mockContracts.Setup(service => service.AddFavorite(favoriteContractDto.UserName, favoriteContractDto.ContractId))
+        _mockContracts.Setup(service => service.AddFavorite(favoriteContractDto.UserId, favoriteContractDto.ContractId))
             .Throws<ContractDoesNotExistException>();
 
         // Act
@@ -89,14 +91,14 @@ public class FavoritesControllerTests
         // Arrange
         var favoriteContractDto = new FavoriteContractDto()
         {
-            UserName = "user", ContractId = Guid.NewGuid(), IsFavorite = true,
+            UserId = Guid.NewGuid(), ContractId = Guid.NewGuid(), IsFavorite = true,
         };
 
         // Act
         _cut.Change(favoriteContractDto);
 
         // Assert
-        _mockContracts.Verify(service => service.AddFavorite(favoriteContractDto.UserName, favoriteContractDto.ContractId), Times.Once);
+        _mockContracts.Verify(service => service.AddFavorite(favoriteContractDto.UserId, favoriteContractDto.ContractId), Times.Once);
     }
 
     [Fact]
@@ -105,26 +107,26 @@ public class FavoritesControllerTests
         // Arrange
         var favoriteContractDto = new FavoriteContractDto()
         {
-            UserName = "user", ContractId = Guid.NewGuid(), IsFavorite = false,
+            UserId = Guid.NewGuid(), ContractId = Guid.NewGuid(), IsFavorite = false,
         };
 
         // Act
         _cut.Change(favoriteContractDto);
 
         // Assert
-        _mockContracts.Verify(service => service.RemoveFavorite(favoriteContractDto.UserName, favoriteContractDto.ContractId), Times.Once);
+        _mockContracts.Verify(service => service.RemoveFavorite(favoriteContractDto.UserId, favoriteContractDto.ContractId), Times.Once);
     }
 
     [Fact]
     public void GetIsFavorite_ReturnsOk_IfTheContractIsMarkedAsFavoriteByTheUser()
     {
         // Arrange
-        string userName = "user";
-        Guid contractId = Guid.NewGuid();
-        _mockContracts.Setup(service => service.IsFavorite(userName, contractId)).Returns(true);
+        var user = new User();
+        var contractId = Guid.NewGuid();
+        _mockContracts.Setup(service => service.IsFavorite(user.Id, contractId)).Returns(true);
 
         // Act
-        IActionResult actual = _cut.GetIsFavorite(userName, contractId);
+        IActionResult actual = _cut.GetIsFavorite(user.Id, contractId);
 
         // Assert
         actual.Should().BeOfType<OkResult>();
@@ -134,12 +136,12 @@ public class FavoritesControllerTests
     public void GetIsFavorite_ReturnsNotFound_IfTheContractIsNotMarkedAsFavoriteByTheUser()
     {
         // Arrange
-        string userName = "user";
-        Guid contractId = Guid.NewGuid();
-        _mockContracts.Setup(service => service.IsFavorite(userName, contractId)).Returns(false);
+        var user = new User();
+        var contractId = Guid.NewGuid();
+        _mockContracts.Setup(service => service.IsFavorite(user.Id, contractId)).Returns(false);
 
         // Act
-        IActionResult actual = _cut.GetIsFavorite(userName, contractId);
+        IActionResult actual = _cut.GetIsFavorite(user.Id, contractId);
 
         // Assert
         actual.Should().BeOfType<NotFoundResult>();
@@ -149,12 +151,12 @@ public class FavoritesControllerTests
     public void GetIsFavorite_ReturnsNotFound_IfTheContractIsNotMarkedAsFavorite()
     {
         // Arrange
-        string userName = string.Empty;
-        Guid contractId = Guid.NewGuid();
-        _mockContracts.Setup(service => service.IsFavorite(userName, contractId)).Returns(false);
+        var user = new User();
+        var contractId = Guid.NewGuid();
+        _mockContracts.Setup(service => service.IsFavorite(user.Id, contractId)).Returns(false);
 
         // Act
-        IActionResult actual = _cut.GetIsFavorite(userName, contractId);
+        IActionResult actual = _cut.GetIsFavorite(user.Id, contractId);
 
         // Assert
         actual.Should().BeOfType<NotFoundResult>();

--- a/tests/Server.Tests/Controllers/RecentsControllerTests.cs
+++ b/tests/Server.Tests/Controllers/RecentsControllerTests.cs
@@ -17,39 +17,39 @@ public class RecentsControllerTests
     }
 
     [Fact]
-    public void FetchRecent_ReturnsEmptyList_WhenUsernameIsEmpty()
+    public void FetchRecent_ReturnsEmptyList_WhenUserIdIsNull()
     {
         // Act
-        IEnumerable<Contract> recentContracts = _cut.RecentContracts(string.Empty);
+        IEnumerable<Contract> recentContracts = _cut.RecentContracts(null);
 
         // Assert
         recentContracts.Should().BeEmpty();
     }
 
     [Fact]
-    public void FetchRecent_DelegatesToService_WhenUsernameIsNotEmpty()
+    public void FetchRecent_DelegatesToService_WhenUserIdIsGiven()
     {
         // Arrange
-        const string username = "123";
+        var userId = Guid.NewGuid();
 
         // Act
-        _cut.RecentContracts(username);
+        _cut.RecentContracts(userId);
 
         // Assert
-        _mockRecent.Verify(recent => recent.FetchRecentContracts(username), Times.Once);
+        _mockRecent.Verify(recent => recent.FetchRecentContracts(userId), Times.Once);
     }
 
     [Fact]
     public void AddRecent_DelegatesToService()
     {
         // Arrange
-        const string username = "123";
+        var userId = Guid.NewGuid();
         var contract = new Contract();
 
         // Act
-        _cut.Add(username, contract);
+        _cut.Add(userId, contract);
 
         // Assert
-        _mockRecent.Verify(recent => recent.Add(username, contract), Times.Once);
+        _mockRecent.Verify(recent => recent.Add(userId, contract), Times.Once);
     }
 }

--- a/tests/Server.Tests/Controllers/UsersControllerTests.cs
+++ b/tests/Server.Tests/Controllers/UsersControllerTests.cs
@@ -1,6 +1,7 @@
 using Application.Contracts;
 using Application.Exceptions;
 using Application.Users;
+
 using Domain.Contracts;
 using Domain.Users;
 
@@ -47,11 +48,26 @@ public class UsersControllerTests
     }
 
     [Fact]
+    public void Create_ReturnsBadRequest_WhenNameIsTaken()
+    {
+        // Arrange
+        var user = new User();
+        _mockUsers.Setup(service => service.Add(user)).Throws<UserNameTakenException>();
+
+        // Act
+        IActionResult actual = _cut.Create(user, user.Id);
+
+        // Assert
+        actual.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
     public void Authenticate_ReturnsOk_IfUserExistsAndPasswordIsCorrect()
     {
         // Arrange
         var user = new User() { Name = "user", Password = "password", };
-        _mockUsers.Setup(service => service.Authenticate(user.Name, user.Password)).Returns(new AuthenticateResponse(user, "token"));
+        _mockUsers.Setup(service => service.Authenticate(user.Name, user.Password))
+                  .Returns(new AuthenticateResponse(user, "token"));
 
         // Act
         IActionResult actual = _cut.Authenticate(user);


### PR DESCRIPTION
## Summary
Replaces the use of usernames instead of IDs everywhere in the code, and disallows users with the same name.

![chrome_35LhYvwmfF](https://user-images.githubusercontent.com/12572888/169099516-66cf4a46-3407-4ea1-9699-8944df0af074.gif)

Closes #132
