### PR TITLE
Hotfix put endpoints

### DIFF
--- a/src/Client/Pages/Admin/ContractComponents/ContractForm.razor
+++ b/src/Client/Pages/Admin/ContractComponents/ContractForm.razor
@@ -257,7 +257,7 @@
     {
         string json = JsonConvert.SerializeObject(_contract);
         var content = new StringContent(json, Encoding.UTF8, "application/json");
-        HttpResponseMessage response = await _http.PutAsync($"api/v1/contracts/{_contract.Id}", content);
+        HttpResponseMessage response = await _http.PutAsync("api/v1/contracts", content);
         if (response.IsSuccessStatusCode)
         {
             await OnContractUploaded.InvokeAsync(_contract);

--- a/src/Client/Pages/Admin/UserComponents/UserForm.razor
+++ b/src/Client/Pages/Admin/UserComponents/UserForm.razor
@@ -86,7 +86,7 @@
     {
         string json = JsonConvert.SerializeObject(_user);
         var content = new StringContent(json, Encoding.UTF8, "application/json");
-        HttpResponseMessage response = await _http.PutAsync($"api/v1/users/{_user.Id}", content);
+        HttpResponseMessage response = await _http.PutAsync($"api/v1/users", content);
         if (response.IsSuccessStatusCode)
         {
             await OnUserAdded.InvokeAsync(_user);

--- a/src/Server/Controllers/ContractsController.cs
+++ b/src/Server/Controllers/ContractsController.cs
@@ -53,13 +53,12 @@ public class ContractsController : BaseApiController<ContractsController>
     /// Creates a new contract.
     /// </summary>
     /// <param name="contract">The contract to put.</param>
-    /// <param name="id">The identifier of the contract to put.</param>
     /// <returns>The identifier of the stored image.</returns>
     /// <response code="400">The ID of the contract was already taken.</response>
-    [HttpPut("{id:guid}")]
+    [HttpPut]
     [Authorize("AdminOnly")]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public IActionResult CreateContract([FromBody] Contract contract, Guid id)
+    public IActionResult CreateContract([FromBody] Contract contract)
     {
         try
         {

--- a/src/Server/Controllers/UsersController.cs
+++ b/src/Server/Controllers/UsersController.cs
@@ -35,13 +35,12 @@ public class UsersController : BaseApiController<UsersController>
     /// Creates a new user.
     /// </summary>
     /// <param name="user">The user to add.</param>
-    /// <param name="id">The identifier of the user to put.</param>
     /// <returns>If the user was successfully added.</returns>
     /// <response code="400">The ID of the user was already taken.</response>
-    [HttpPut("{id:guid}")]
+    [HttpPut]
     [Authorize("AdminOnly")]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public IActionResult Create([FromBody] User user, Guid id)
+    public IActionResult Create([FromBody] User user)
     {
         try
         {

--- a/tests/Server.Tests.Integration/Authentication/AuthIntegrationTests.cs
+++ b/tests/Server.Tests.Integration/Authentication/AuthIntegrationTests.cs
@@ -23,11 +23,10 @@ public class AuthIntegrationTests : IntegrationTest
     {
         get
         {
-            var user = new User { Name = "Unique name", };
             var contract = new Contract();
             return new List<object[]>
             {
-                new object[] { $"/api/v1/users/{user.Id}", user, },
+                new object[] { $"/api/v1/users", new User { Name = "Unique name", }, },
                 new object[] { $"/api/v1/contracts/{contract.Id}", contract, },
             };
         }
@@ -42,13 +41,13 @@ public class AuthIntegrationTests : IntegrationTest
             Func<HttpClient, Task> createContract =
                 async client => await client.PutAsJsonAsync(contractEndpoint, contract);
 
-            var user = new User();
-            string usersEndpoint = $"/api/v1/users/{user.Id}";
-            Func<HttpClient, Task> createUser = async client => await client.PutAsJsonAsync(usersEndpoint, user);
+            var user = new User { Name = "User Usersson", };
+            Func<HttpClient, Task> createUser = async client => await client.PutAsJsonAsync("/api/v1/users", user);
 
             return new List<object[]>
             {
-                new object[] { contractEndpoint, createContract, }, new object[] { usersEndpoint, createUser, },
+                new object[] { contractEndpoint, createContract, },
+                new object[] { $"/api/v1/users/{user.Id}", createUser, },
             };
         }
     }

--- a/tests/Server.Tests.Integration/Authentication/AuthIntegrationTests.cs
+++ b/tests/Server.Tests.Integration/Authentication/AuthIntegrationTests.cs
@@ -23,11 +23,10 @@ public class AuthIntegrationTests : IntegrationTest
     {
         get
         {
-            var contract = new Contract();
             return new List<object[]>
             {
-                new object[] { $"/api/v1/users", new User { Name = "Unique name", }, },
-                new object[] { $"/api/v1/contracts/{contract.Id}", contract, },
+                new object[] { "/api/v1/users", new User { Name = "Unique name", }, },
+                new object[] { "/api/v1/contracts", new Contract(), },
             };
         }
     }
@@ -37,16 +36,15 @@ public class AuthIntegrationTests : IntegrationTest
         get
         {
             var contract = new Contract();
-            string contractEndpoint = $"/api/v1/contracts/{contract.Id}";
             Func<HttpClient, Task> createContract =
-                async client => await client.PutAsJsonAsync(contractEndpoint, contract);
+                async client => await client.PutAsJsonAsync("/api/v1/contracts", contract);
 
             var user = new User { Name = "User Usersson", };
             Func<HttpClient, Task> createUser = async client => await client.PutAsJsonAsync("/api/v1/users", user);
 
             return new List<object[]>
             {
-                new object[] { contractEndpoint, createContract, },
+                new object[] { $"/api/v1/contracts/{contract.Id}", createContract, },
                 new object[] { $"/api/v1/users/{user.Id}", createUser, },
             };
         }
@@ -151,7 +149,7 @@ public class AuthIntegrationTests : IntegrationTest
     {
         // Arrange
         var contract = new Contract();
-        await PutResourceAsync($"/api/v1/contracts/{contract.Id}", contract);
+        await PutResourceAsync($"/api/v1/contracts", contract);
 
         // Act
         HttpResponseMessage response = await Client.GetAsync("/api/v1/contracts");
@@ -195,7 +193,7 @@ public class AuthIntegrationTests : IntegrationTest
     {
         // Arrange
         var contract = new Contract();
-        await PutResourceAsync($"/api/v1/contracts/{contract.Id}", contract);
+        await PutResourceAsync($"/api/v1/contracts", contract);
 
         await ArrangeAuthenticatedUserAsync();
 

--- a/tests/Server.Tests.Integration/Contracts/ContractApiIntegrationTests.cs
+++ b/tests/Server.Tests.Integration/Contracts/ContractApiIntegrationTests.cs
@@ -21,7 +21,7 @@ public class ContractApiIntegrationTests : IntegrationTest
         var newContract = new Contract();
 
         // Act
-        HttpResponseMessage response = await Client.PutAsJsonAsync($"api/v1/contracts/{newContract.Id}", newContract);
+        HttpResponseMessage response = await Client.PutAsJsonAsync("api/v1/contracts", newContract);
 
         // Assert
         response.Should().BeSuccessful();
@@ -34,7 +34,7 @@ public class ContractApiIntegrationTests : IntegrationTest
     {
         // Arrange
         var contract = new Contract();
-        string endpointUrl = $"api/v1/contracts/{contract.Id}";
+        const string endpointUrl = $"api/v1/contracts";
         await PutResourceAsync(endpointUrl, contract);
         await ArrangeAuthenticatedAdminAsync();
         contract.Name = "Modified name";

--- a/tests/Server.Tests.Integration/IntegrationTest.cs
+++ b/tests/Server.Tests.Integration/IntegrationTest.cs
@@ -62,7 +62,7 @@ public class IntegrationTest : IClassFixture<TestWebApplicationFactory>
 
         // Arrange - create normal user.
         var user = new User();
-        await Client.PutAsJsonAsync($"/api/v1/users/{user.Id}", user);
+        await Client.PutAsJsonAsync($"/api/v1/users", user);
 
         // Arrange - authenticate as normal user.
         HttpResponseMessage authResponseMessage =

--- a/tests/Server.Tests/Controllers/UsersControllerTests.cs
+++ b/tests/Server.Tests/Controllers/UsersControllerTests.cs
@@ -29,7 +29,7 @@ public class UsersControllerTests
         _mockUsers.Setup(service => service.Add(user)).Throws<IdentifierAlreadyTakenException>();
 
         // Act
-        IActionResult actual = _cut.Create(user, user.Id);
+        IActionResult actual = _cut.Create(user);
 
         // Assert
         actual.Should().BeOfType<OkResult>();
@@ -41,7 +41,7 @@ public class UsersControllerTests
         // Arrange
 
         // Act
-        IActionResult actual = _cut.Create(new User(), Guid.NewGuid());
+        IActionResult actual = _cut.Create(new User());
 
         // Assert
         actual.Should().BeOfType<OkResult>();
@@ -55,7 +55,7 @@ public class UsersControllerTests
         _mockUsers.Setup(service => service.Add(user)).Throws<UserNameTakenException>();
 
         // Act
-        IActionResult actual = _cut.Create(user, user.Id);
+        IActionResult actual = _cut.Create(user);
 
         // Assert
         actual.Should().BeOfType<BadRequestObjectResult>();


### PR DESCRIPTION
Makes our `PUT /api/v1/contracts` and `PUT /api/v1/users` endpoints conform to API formatting guidelines.
