### PR TITLE
178 remastered loading indicator

### DIFF
--- a/src/Client/Pages/Contracts/ContractsPage.razor
+++ b/src/Client/Pages/Contracts/ContractsPage.razor
@@ -6,7 +6,7 @@
 
 <PageTitle>Prodigo Portal - Kontrakt</PageTitle>
 
-<div class="container">
+<div class="container minimum-height d-flex flex-column">
     <SearchBar OnQueryChange="OnQueryChanged"/>
 
     <RecentlyViewed @ref="_recentlyViewed"/>

--- a/src/Client/Pages/Contracts/ContractsPage.razor.css
+++ b/src/Client/Pages/Contracts/ContractsPage.razor.css
@@ -7,4 +7,3 @@
     padding-top: 1em;
     padding-bottom: 1em;
 }
-

--- a/src/Client/Pages/WelcomePage.razor.css
+++ b/src/Client/Pages/WelcomePage.razor.css
@@ -4,7 +4,7 @@
     margin-left: 0;
     margin-right: 0;
     width: 100%;
-    height: calc(100vh - 3.5rem);
+    height: calc(100vh - 4.5rem);
     background-size: cover;
     align-items: center;
 }

--- a/src/Client/Shared/LoadingIndicator.razor
+++ b/src/Client/Shared/LoadingIndicator.razor
@@ -1,5 +1,5 @@
 ﻿<div class="spinner-border loading-indicator" role="status">
-  <span class="visually-hidden">Loading...</span>
+  <span class="visually-hidden">Laddar...</span>
 </div>
 
 @code {

--- a/src/Client/Shared/LoadingIndicator.razor
+++ b/src/Client/Shared/LoadingIndicator.razor
@@ -1,4 +1,4 @@
-﻿<div class="d-flex justify-content-center align-items-center">
+﻿<div class="d-flex justify-content-center align-items-center flex-fill">
     <div class="spinner-border loading-indicator m-3" role="status">
       <span class="visually-hidden">Laddar...</span>
     </div>

--- a/src/Client/Shared/LoadingIndicator.razor
+++ b/src/Client/Shared/LoadingIndicator.razor
@@ -1,7 +1,5 @@
-﻿<div class="spinner-border loading-indicator" role="status">
-  <span class="visually-hidden">Laddar...</span>
+﻿<div class="d-flex justify-content-center align-items-center">
+    <div class="spinner-border loading-indicator m-3" role="status">
+      <span class="visually-hidden">Laddar...</span>
+    </div>
 </div>
-
-@code {
-
-}

--- a/src/Client/Shared/LoadingIndicator.razor
+++ b/src/Client/Shared/LoadingIndicator.razor
@@ -1,4 +1,6 @@
-﻿<p class="loading-indicator">Laddar...</p>
+﻿<div class="spinner-border loading-indicator" role="status">
+  <span class="visually-hidden">Loading...</span>
+</div>
 
 @code {
 

--- a/src/Client/wwwroot/css/app.css
+++ b/src/Client/wwwroot/css/app.css
@@ -90,7 +90,7 @@ footer a:hover {
 }
 
 article {
-    min-height: calc(100vh - 3.5rem);
+    min-height: calc(100vh - 4.5rem);
 }
 
 .btn-primary {
@@ -158,4 +158,8 @@ td {
 thead {
     background-color: var(--prodigo-black);
     color: var(--prodigo-white);
+}
+
+.minimum-height {
+    min-height: calc(100vh - 4.5rem);
 }

--- a/src/Client/wwwroot/index.html
+++ b/src/Client/wwwroot/index.html
@@ -29,7 +29,15 @@
 </head>
 
 <body>
-<div id="app">Loading...</div>
+<div id="app">
+    <!-- Loading indicator shown during Blazor initialization. -->
+    <div class="d-flex flex-column justify-content-center align-items-center vh-100">
+        <h1 class="h3">Prodigo Portal laddas in...</h1>
+        <div class="spinner-border loading-indicator m-3" role="status">
+            <span class="visually-hidden">Laddar...</span>
+        </div>
+    </div>
+</div>
 
 <div id="blazor-error-ui">
     An unhandled error has occurred.

--- a/tests/Client.Tests/Pages/Admin/AdminPageTests.cs
+++ b/tests/Client.Tests/Pages/Admin/AdminPageTests.cs
@@ -18,7 +18,7 @@ public class AdminPageTests : UITestFixture
     }
 
     [Fact]
-    public void AdminPage_ShouldSayLoading_WhenThereAreNoContractsFetched()
+    public void AdminPage_ShouldShowLoadingIndicator_WhenThereAreNoContractsFetched()
     {
         // Arrange
         MockHttp.When("/api/v1/contracts").Respond(async () =>
@@ -33,7 +33,7 @@ public class AdminPageTests : UITestFixture
         IRenderedComponent<ContractsPage> cut = Context.RenderComponent<ContractsPage>();
 
         // Assert
-        cut.WaitForAssertion(() => cut.Find(".loading-indicator").TextContent.Should().BeEquivalentTo("Laddar..."));
+        cut.WaitForElement(".loading-indicator");
     }
 
     [Fact]

--- a/tests/Client.Tests/Pages/Contracts/ContractsPageTests.cs
+++ b/tests/Client.Tests/Pages/Contracts/ContractsPageTests.cs
@@ -16,7 +16,7 @@ public class ContractsPageTests : UITestFixture
     }
 
     [Fact]
-    public void ContractPage_ShouldSayLoading_WhenThereAreNoContractsFetched()
+    public void ContractPage_ShouldShowLoadingIndicator_WhenThereAreNoContractsFetched()
     {
         // Arrange
         MockHttp.When("/api/v1/contracts").Respond(async () =>
@@ -31,7 +31,7 @@ public class ContractsPageTests : UITestFixture
         IRenderedComponent<ContractsPage> cut = Context.RenderComponent<ContractsPage>();
 
         // Assert
-        cut.WaitForAssertion(() => cut.Find(".loading-indicator").TextContent.Should().BeEquivalentTo("Laddar..."));
+        cut.WaitForElement(".loading-indicator");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Restyles the loading indicator to be an animated spinner, and replaces the loading indicator shown before Blazor is initialized.

![chrome_qsym02z3Or](https://user-images.githubusercontent.com/12572888/169643112-f6d7c7a0-9aff-4b80-8196-726596c4d982.gif)

## Definition of done
- [x] All acceptance criteria are completed.
- [x] The code has (at least) 80% branch test coverage.
- [x] All tests pass.
- [x] The code is reviewed and accepted by (at least) two other team members.
- [x] Views adhere to design style.

Closes #178
